### PR TITLE
fix(docs): favicon/app-icon 绝对路径漏拼 BASE_PATH 导致 GitHub Pages 子路径下 404

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Provider } from "@/components/provider";
 import { appIconPath, appName, appTagline } from "@/lib/shared";
-import { SITE_ORIGIN } from "@/lib/site";
+import { BASE_PATH, SITE_ORIGIN } from "@/lib/site";
 import "./global.css";
 
 export const metadata: Metadata = {
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
   icons: {
     icon: [
       { url: appIconPath, type: "image/svg+xml" },
-      { url: "/favicon.ico", sizes: "any" },
+      { url: `${BASE_PATH}/favicon.ico`, sizes: "any" },
     ],
   },
 };

--- a/docs/lib/shared.ts
+++ b/docs/lib/shared.ts
@@ -1,6 +1,10 @@
+import { BASE_PATH } from "./site";
+
 export const appName = "SwarmDrop";
 export const appTagline = "Drop files anywhere. No cloud. No limits.";
-export const appIconPath = "/app-icon.svg";
+// GitHub Pages 部署在 /SwarmDrop 子路径下，纯字符串路径（不像 next/image、next/link
+// 那样能被框架自动加前缀）必须手动拼 BASE_PATH，否则会被解析成域名根路径 404。
+export const appIconPath = `${BASE_PATH}/app-icon.svg`;
 export const docsRoute = "/docs";
 export const docsImageRoute = "/og/docs";
 export const docsContentRoute = "/llms.mdx/docs";


### PR DESCRIPTION
docs 站点部署在 https://swarm-apps.github.io/SwarmDrop/ 子路径下，next.config.mjs 已经通过 PAGES_BASE_PATH 注入 basePath、并暴露 NEXT_PUBLIC_BASE_PATH 供客户端拼 绝对路径（docs/lib/site.ts 的 BASE_PATH），但 app-icon.svg / favicon.ico 的引用 是裸字符串 "/xxx"，没有走这个机制——不像 next/image、next/link 那样会被框架自动 加前缀，实际请求会打到域名根路径 404。

docs/lib/shared.ts 的 appIconPath 和 docs/app/layout.tsx 里的 favicon.ico 都 改成显式拼 BASE_PATH。用 PAGES_BASE_PATH=/SwarmDrop pnpm build 实测过，产物 HTML 里的引用都正确带上了 /SwarmDrop 前缀。