### PR TITLE
fix(window): Windows/Linux 全屏路由补回窗口控制顶条

### DIFF
--- a/src/components/layout/app-topbar.tsx
+++ b/src/components/layout/app-topbar.tsx
@@ -251,8 +251,9 @@ function ThemeShortcut() {
   );
 }
 
-/** Windows / Linux 自画窗口控制按钮(最小化 / 最大化 / 关闭) */
-function WindowControls() {
+/** Windows / Linux 自画窗口控制按钮(最小化 / 最大化 / 关闭)。
+ *  全屏路由（发送 / 配对）隐藏 AppTopBar 时，需在页面自己的顶栏复用它。 */
+export function WindowControls() {
   const { t } = useLingui();
   const appWindow = getCurrentWindow();
 

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -10,7 +10,7 @@ import {
   AppAmbientBackground,
   AppAmbientLightOverlay,
 } from "@/components/layout/app-ambient-background";
-import { AppTopBar } from "@/components/layout/app-topbar";
+import { AppTopBar, WindowControls } from "@/components/layout/app-topbar";
 import { useNetworkStore } from "@/stores/network-store";
 import { usePreferencesStore } from "@/stores/preferences-store";
 import { ConnectionRequestDialog } from "@/components/pairing/connection-request-dialog";
@@ -57,12 +57,20 @@ function AppLayout() {
     <div className="app-shell flex h-svh flex-col">
       <AppAmbientBackground />
       {!isFullScreenRoute && <AppTopBar />}
-      {isFullScreenRoute && isMac && (
-        <div
-          data-tauri-drag-region
-          className="h-8 shrink-0 bg-background"
-        />
-      )}
+      {/* 全屏路由无 AppTopBar：Windows/Linux 是无边框自绘窗口
+          (setup.rs set_decorations(false))，需补一条可拖拽、带窗口控制的玻璃顶条；
+          macOS 走系统 Overlay 红绿灯，只留等高拖拽占位。 */}
+      {isFullScreenRoute &&
+        (isMac ? (
+          <div data-tauri-drag-region className="h-8 shrink-0 bg-background" />
+        ) : (
+          <div
+            data-tauri-drag-region
+            className="flex h-9 shrink-0 items-center justify-end bg-white/[0.16] pr-2 backdrop-blur-xl dark:bg-slate-950/[0.10]"
+          >
+            <WindowControls />
+          </div>
+        ))}
       <main className="flex-1 overflow-hidden">
         <Outlet />
       </main>


### PR DESCRIPTION
修复 Windows/Linux 上发送/配对全屏页无窗口控制、无法拖动窗口的问题。这两个平台是无边框自绘窗口(setup.rs set_decorations(false)),窗口控制全靠前端 WindowControls,而全屏路由隐藏了 AppTopBar,原先只给 macOS 补了拖拽占位。现按平台分支:非 mac 渲染一条可拖拽玻璃顶条 + WindowControls,与 TaskToolbar 同款玻璃底、无底边框拼成整条 header。
