### PR TITLE
fix(docs): 用 docs 独立 workspace 修复 Pages 部署

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,15 +38,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: docs/pnpm-lock.yaml
 
-      # docs 是自带 lockfile 的独立子项目。仓库根有 pnpm-workspace.yaml
-      # (packages: - .，不含 docs)；在 docs 下装依赖时 pnpm 会向上找到根
-      # workspace 并按它安装（把根依赖装进根 node_modules），导致 docs/node_modules
-      # 为空、后续 next build 报 next: not found。--ignore-workspace 让 pnpm 忽略
-      # 根 workspace，把 docs 当独立项目、用 docs/pnpm-lock.yaml 安装。
-      # 依赖的 native 包（esbuild/@tailwindcss/oxide/sharp 等）由预编译平台子包提供
-      # 二进制，无需其 build 脚本，故这里无需额外 approve-builds。
+      # docs 通过自身的 docs/pnpm-workspace.yaml 建立独立 workspace 边界，
+      # 避免被仓库根 workspace 劫持安装；native 依赖的 build 脚本也在该文件里 allowBuilds。
       - name: pnpm install
-        run: pnpm install --frozen-lockfile --ignore-workspace
+        run: pnpm install --frozen-lockfile
 
       - name: Build docs (static export)
         env:

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,18 @@
+# docs 是独立于仓库根的子项目（自带 package.json / pnpm-lock.yaml）。
+#
+# 这个文件给 docs 建立独立的 pnpm workspace 边界：pnpm 在 docs 下运行时会向上
+# 查找最近的 pnpm-workspace.yaml，有了本文件就停在 docs、以 docs 为 workspace 根，
+# 不会再向上找到仓库根的 pnpm-workspace.yaml（其 `packages: - .` 不含 docs）而
+# “劫持”本目录的安装——被劫持时会按根依赖装进根 node_modules、docs/node_modules 为空，
+# 导致 CI 里 `next build` 报 next: not found。
+packages:
+  - .
+
+# pnpm 10+ 默认不执行未批准依赖的 build 脚本，且在 frozen 安装下会以非零码退出
+# （ERR_PNPM_IGNORED_BUILDS）。这里批准 docs 依赖里带 native 二进制的包运行其构建脚本，
+# 与仓库根 pnpm-workspace.yaml 的 allowBuilds 写法保持一致。
+allowBuilds:
+  esbuild: true
+  sharp: true
+  "@tailwindcss/oxide": true
+  unrs-resolver: true


### PR DESCRIPTION
接续 #42。改用 docs/pnpm-workspace.yaml 建立独立 workspace 边界(阻止根 workspace 劫持) + allowBuilds 批准 native 依赖构建脚本，CI 撤回 --ignore-workspace。已在真实布局本地验证 frozen 安装 exit=0、无 ERR_PNPM_IGNORED_BUILDS、lockfile 零 diff。