### PR TITLE
feat(inbox): 收件箱详情页支持复制本地路径

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,8 @@ pnpm build
 | Routing | TanStack Router (file-system based, auto code-splitting) |
 | State | Zustand 5 (stores: auth, network, preferences, secret, pairing, transfer) |
 | UI | shadcn/ui (new-york style), Lucide icons, Radix primitives |
-| i18n | Lingui 5 (8 locales: zh, zh-TW, en, ja, ko, es, fr, de) |
-| Backend | Rust 2021, Tauri 2 |
+| i18n | Lingui 5 (3 locales: zh, zh-TW, en — ja/ko/es/fr/de are roadmap targets, not yet added) |
+| Backend | Rust 2024, Tauri 2 |
 | P2P | libp2p 0.56 via `swarm-p2p-core` (git submodule in `libs/`) |
 | Security | Stronghold (encrypted vault), Biometry (FaceID/TouchID/Windows Hello) |
 | Database | SeaORM 2.0 + SQLite (传输历史、断点续传 checkpoint) |

--- a/dev-notes/knowledge/theme-and-styling.md
+++ b/dev-notes/knowledge/theme-and-styling.md
@@ -80,7 +80,7 @@ Lingui 配置 `sourceLocale: "zh"`，意味着代码里写 `<Trans>添加设备<
 
 ### 实际只有 3 个 locale
 
-CLAUDE.md 顶部写"8 locales (zh, zh-TW, en, ja, ko, es, fr, de)"——这是规划目标，**当前实际只有 zh / zh-TW / en**（见 `lingui.config.ts` 与 `src/locales/`）。加新语言前先确认 Aurora / 字体 fallback 等下游是否准备好。
+ja / ko / es / fr / de 是规划目标，**当前实际只有 zh / zh-TW / en**（见 `lingui.config.ts` 与 `src/locales/`）。加新语言前先确认 Aurora / 字体 fallback 等下游是否准备好。
 
 ## Zustand selector 与派生数组
 

--- a/dev-notes/knowledge/toolchain.md
+++ b/dev-notes/knowledge/toolchain.md
@@ -231,7 +231,7 @@ Tauri dev 期间硬编码连这两个端口。改 `vite.config.ts` 端口会让 
 
 **克隆后必须**：`git submodule update --init --recursive`，否则 `cargo build` 找不到 `swarm-p2p-core`。
 
-**注意**：`libs/core` 使用 **Rust 2024 edition**，与主仓 2021 edition 不同——给 submodule 加新文件时注意 edition 差异（比如 `unsafe` block 在 2024 更严格）。
+**注意**：`libs/` 和主仓都是 **Rust 2024 edition**（各自 `[workspace.package] edition = "2024"`，成员 crate 通过 `edition.workspace = true` 继承），两边没有 edition 差异。
 
 ## Lingui 提取
 
@@ -242,7 +242,9 @@ sourceLocale: "zh",
 locales: ["zh", "zh-TW", "en"],
 ```
 
-CLAUDE.md 顶部写"8 locales"——那是规划目标，**当前实际是 3 个**。新增 locale 前先确认设计资源就绪。
+ja/ko/es/fr/de 只是规划目标，**当前实际是 3 个**。新增 locale 前先确认设计资源就绪。
+
+补翻译时只需覆盖这 3 个；`src/locales/` 下没有其它语言目录，不要为尚未落地的 locale 建空目录。
 
 ### 提取命令必须先于 commit
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -737,10 +737,18 @@ msgstr "Processing..."
 msgid "复制"
 msgstr "Copy"
 
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "复制失败，请手动复制路径"
+msgstr "Copy failed, please copy the path manually"
+
 #: src/routes/_app/devices/-components/add-device-section.tsx
 #: src/routes/_app/pairing/generate.lazy.tsx
 msgid "复制失败，请手动复制配对码"
 msgstr "Copy failed, please copy the pairing code manually"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "复制路径"
+msgstr "Copy path"
 
 #: src/routes/_app/devices/-components/add-device-section.tsx
 #: src/routes/_app/devices/-components/add-device-section.tsx
@@ -885,6 +893,7 @@ msgstr "Unarchived"
 msgid "已复制"
 msgstr "Copied"
 
+#: src/routes/_app/inbox/index.lazy.tsx
 #: src/routes/_app/settings/-device-info-section.tsx
 #: src/routes/_app/settings/-mcp-section.tsx
 msgid "已复制到剪贴板"
@@ -1308,6 +1317,10 @@ msgstr "No transfers in progress"
 #: src/routes/_app/devices/-components/add-device-section.tsx
 msgid "暂无附近设备"
 msgstr "No nearby devices"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "更多位置操作"
+msgstr "More location actions"
 
 #: src/components/transfer/transfer-offer-dialog.tsx
 #: src/routes/_app/settings/-transfer-settings-section.tsx
@@ -1910,6 +1923,10 @@ msgstr "No devices in this group yet"
 #: src/routes/_app/settings/-bootstrap-nodes-section.tsx
 msgid "该节点已存在"
 msgstr "Node already exists"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "该记录没有可用的本地路径"
+msgstr "This item has no local path available"
 
 #: src/routes/_app/settings/index.lazy.tsx
 msgid "语言"

--- a/src/locales/zh-TW/messages.po
+++ b/src/locales/zh-TW/messages.po
@@ -737,10 +737,18 @@ msgstr "處理中..."
 msgid "复制"
 msgstr "複製"
 
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "复制失败，请手动复制路径"
+msgstr "複製失敗，請手動複製路徑"
+
 #: src/routes/_app/devices/-components/add-device-section.tsx
 #: src/routes/_app/pairing/generate.lazy.tsx
 msgid "复制失败，请手动复制配对码"
 msgstr "複製失敗,請手動複製配對碼"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "复制路径"
+msgstr "複製路徑"
 
 #: src/routes/_app/devices/-components/add-device-section.tsx
 #: src/routes/_app/devices/-components/add-device-section.tsx
@@ -885,6 +893,7 @@ msgstr "已取消封存"
 msgid "已复制"
 msgstr "已複製"
 
+#: src/routes/_app/inbox/index.lazy.tsx
 #: src/routes/_app/settings/-device-info-section.tsx
 #: src/routes/_app/settings/-mcp-section.tsx
 msgid "已复制到剪贴板"
@@ -1308,6 +1317,10 @@ msgstr "暫無正在傳輸"
 #: src/routes/_app/devices/-components/add-device-section.tsx
 msgid "暂无附近设备"
 msgstr "暫無附近裝置"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "更多位置操作"
+msgstr "更多位置操作"
 
 #: src/components/transfer/transfer-offer-dialog.tsx
 #: src/routes/_app/settings/-transfer-settings-section.tsx
@@ -1910,6 +1923,10 @@ msgstr "此群組中還沒有裝置"
 #: src/routes/_app/settings/-bootstrap-nodes-section.tsx
 msgid "该节点已存在"
 msgstr "該節點已存在"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "该记录没有可用的本地路径"
+msgstr "此記錄沒有可用的本機路徑"
 
 #: src/routes/_app/settings/index.lazy.tsx
 msgid "语言"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -736,10 +736,18 @@ msgstr "处理中..."
 msgid "复制"
 msgstr "复制"
 
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "复制失败，请手动复制路径"
+msgstr "复制失败，请手动复制路径"
+
 #: src/routes/_app/devices/-components/add-device-section.tsx
 #: src/routes/_app/pairing/generate.lazy.tsx
 msgid "复制失败，请手动复制配对码"
 msgstr "复制失败，请手动复制配对码"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "复制路径"
+msgstr "复制路径"
 
 #: src/routes/_app/devices/-components/add-device-section.tsx
 #: src/routes/_app/devices/-components/add-device-section.tsx
@@ -884,6 +892,7 @@ msgstr "已取消归档"
 msgid "已复制"
 msgstr "已复制"
 
+#: src/routes/_app/inbox/index.lazy.tsx
 #: src/routes/_app/settings/-device-info-section.tsx
 #: src/routes/_app/settings/-mcp-section.tsx
 msgid "已复制到剪贴板"
@@ -1307,6 +1316,10 @@ msgstr "暂无正在传输"
 #: src/routes/_app/devices/-components/add-device-section.tsx
 msgid "暂无附近设备"
 msgstr "暂无附近设备"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "更多位置操作"
+msgstr "更多位置操作"
 
 #: src/components/transfer/transfer-offer-dialog.tsx
 #: src/routes/_app/settings/-transfer-settings-section.tsx
@@ -1909,6 +1922,10 @@ msgstr "该分组中还没有设备"
 #: src/routes/_app/settings/-bootstrap-nodes-section.tsx
 msgid "该节点已存在"
 msgstr "该节点已存在"
+
+#: src/routes/_app/inbox/index.lazy.tsx
+msgid "该记录没有可用的本地路径"
+msgstr "该记录没有可用的本地路径"
 
 #: src/routes/_app/settings/index.lazy.tsx
 msgid "语言"

--- a/src/routes/_app/inbox/index.lazy.tsx
+++ b/src/routes/_app/inbox/index.lazy.tsx
@@ -23,6 +23,8 @@ import {
   ArchiveRestore,
   ArrowRightLeft,
   Bot,
+  ChevronDown,
+  Copy,
   FileArchive,
   FolderOpen,
   Inbox,
@@ -50,6 +52,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { CenteredEmptyState } from "@/components/layout/section-primitives";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -81,6 +89,16 @@ type RunAndRefresh = (
   success?: string,
   detailId?: string | null,
 ) => Promise<InboxItemSummary[] | null>;
+
+/**
+ * 可复制的本地路径：单文件取文件自身，多文件取所在目录，与 Rust 侧
+ * `item_target_path` 同一优先级。但这里不校验路径是否仍存在——文件已缺失时
+ * 用户仍需要拿到路径去排查，所以复制不走后端的 `ensure_path_exists`。
+ */
+function inboxItemPath(detail: InboxItemDetail): string | null {
+  if (detail.files.length === 1) return detail.files[0].localPath;
+  return detail.rootPath;
+}
 
 function InboxPage() {
   const { item, q, archived } = Route.useSearch();
@@ -256,6 +274,17 @@ function InboxPage() {
     if (!selectedId) return;
     void runAndRefresh(() => commands.showInboxItemInFolder(selectedId, null));
   };
+  const handleCopyPath = () => {
+    const path = selectedDetail ? inboxItemPath(selectedDetail) : null;
+    if (!path) {
+      toast.error(t`该记录没有可用的本地路径`);
+      return;
+    }
+    void navigator.clipboard.writeText(path).then(
+      () => toast.success(t`已复制到剪贴板`),
+      () => toast.error(t`复制失败，请手动复制路径`),
+    );
+  };
   const handleOpenTransfer = () => {
     if (!selectedItem?.transferSessionId) return;
     void navigate({
@@ -318,6 +347,7 @@ function InboxPage() {
             contained={!isCompact}
             onOpenList={openList ?? undefined}
             onReveal={handleReveal}
+            onCopyPath={handleCopyPath}
             onOpenTransfer={
               selectedItem?.transferSessionId ? handleOpenTransfer : null
             }
@@ -746,6 +776,7 @@ function InboxReader({
   contained,
   onOpenList,
   onReveal,
+  onCopyPath,
   onOpenTransfer,
   onArchive,
   onDelete,
@@ -758,6 +789,7 @@ function InboxReader({
   /** 窄屏传入即渲染详情头部前导「打开列表」按钮；宽屏双栏不传。 */
   onOpenList?: () => void;
   onReveal: () => void;
+  onCopyPath: () => void;
   onOpenTransfer: (() => void) | null;
   onArchive: () => void;
   onDelete: () => void;
@@ -786,6 +818,7 @@ function InboxReader({
           contained={contained}
           leading={toggle}
           onReveal={onReveal}
+          onCopyPath={onCopyPath}
           onOpenTransfer={onOpenTransfer}
           onArchive={onArchive}
           onDelete={onDelete}
@@ -826,6 +859,7 @@ function ReaderContent({
   contained,
   leading,
   onReveal,
+  onCopyPath,
   onOpenTransfer,
   onArchive,
   onDelete,
@@ -836,6 +870,7 @@ function ReaderContent({
   contained: boolean;
   leading?: ReactNode;
   onReveal: () => void;
+  onCopyPath: () => void;
   /** 跳到该条目对应的传输记录；无关联传输时为 null（不渲染按钮）。 */
   onOpenTransfer: (() => void) | null;
   onArchive: () => void;
@@ -908,10 +943,29 @@ function ReaderContent({
         </div>
 
         <div className="mt-5 flex flex-wrap gap-2">
-          <Button size="sm" className="gap-1.5" onClick={onReveal}>
-            <FolderOpen className="size-4" />
-            <Trans>在文件夹中显示</Trans>
-          </Button>
+          <div className="inline-flex">
+            <Button size="sm" className="gap-1.5 rounded-r-none" onClick={onReveal}>
+              <FolderOpen className="size-4" />
+              <Trans>在文件夹中显示</Trans>
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="sm"
+                  aria-label={t`更多位置操作`}
+                  className="rounded-l-none border-l border-primary-foreground/25 has-[>svg]:px-2"
+                >
+                  <ChevronDown className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={onCopyPath}>
+                  <Copy className="size-4" />
+                  <Trans>复制路径</Trans>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
           {onOpenTransfer && (
             <Button
               size="sm"


### PR DESCRIPTION
## 概述
实现 #44：收件箱详情页在「在文件夹中显示」旁增加下拉菜单，支持复制已接收内容的本地路径。

顺带修正了 CLAUDE.md 与知识库中 locale 数量、Rust edition 的过期描述（独立 commit，可单独 review）。

## 验收对照
- [x] 保留「在文件夹中显示」
- [x] 下拉菜单可复制路径
- [x] 单文件记录复制文件路径
- [x] 多文件记录复制文件夹路径
- [x] 文件缺失但记录有路径时仍可复制
- [x] 无可用路径时明确提示
- [x] 文案覆盖 zh / zh-TW / en