### PR TITLE
Enable WebRTC Direct on native endpoints

### DIFF
--- a/crates/core/src/host.rs
+++ b/crates/core/src/host.rs
@@ -200,6 +200,14 @@ impl KeychainProvider for MemoryHost {
         Ok(())
     }
 
+    async fn delete_webrtc_certificate_pem(&self) -> AppResult<()> {
+        self.inner
+            .lock()
+            .expect("memory host poisoned")
+            .webrtc_certificate_pem = None;
+        Ok(())
+    }
+
     async fn load_migration_state(&self) -> AppResult<IdentityMigrationState> {
         Ok(self
             .inner

--- a/crates/core/src/host.rs
+++ b/crates/core/src/host.rs
@@ -112,6 +112,7 @@ pub struct MemoryHost {
 #[derive(Debug, Default)]
 struct MemoryHostInner {
     identity: Option<DeviceIdentityBytes>,
+    webrtc_certificate_pem: Option<String>,
     migration_state: Option<IdentityMigrationState>,
     paired_devices: Vec<PairedDeviceInfo>,
     events: Vec<CoreEvent>,
@@ -179,6 +180,23 @@ impl KeychainProvider for MemoryHost {
 
     async fn delete_identity(&self) -> AppResult<()> {
         self.inner.lock().expect("memory host poisoned").identity = None;
+        Ok(())
+    }
+
+    async fn load_webrtc_certificate_pem(&self) -> AppResult<Option<String>> {
+        Ok(self
+            .inner
+            .lock()
+            .expect("memory host poisoned")
+            .webrtc_certificate_pem
+            .clone())
+    }
+
+    async fn save_webrtc_certificate_pem(&self, pem: String) -> AppResult<()> {
+        self.inner
+            .lock()
+            .expect("memory host poisoned")
+            .webrtc_certificate_pem = Some(pem);
         Ok(())
     }
 

--- a/crates/core/src/identity.rs
+++ b/crates/core/src/identity.rs
@@ -55,6 +55,24 @@ where
     })
 }
 
+/// 读取或首次生成 WebRTC Direct 证书。
+///
+/// 证书 PEM 必须整体持久化；仅重建密钥仍会因证书中的随机字段改变 certhash，
+/// 导致已经发出的邀请地址失效。此函数仅在原生宿主编译。
+#[cfg(not(target_family = "wasm"))]
+pub async fn load_or_create_webrtc_certificate<P>(provider: &P) -> AppResult<String>
+where
+    P: KeychainProvider + ?Sized,
+{
+    if let Some(pem) = provider.load_webrtc_certificate_pem().await? {
+        return Ok(pem);
+    }
+
+    let pem = swarmdrop_net::generate_webrtc_certificate_pem().map_err(AppError::Network)?;
+    provider.save_webrtc_certificate_pem(pem.clone()).await?;
+    Ok(pem)
+}
+
 /// 读取已配对设备列表。
 pub async fn load_paired_devices<P>(provider: &P) -> AppResult<Vec<PairedDeviceInfo>>
 where
@@ -216,6 +234,21 @@ mod tests {
         assert!(!loaded.created);
         assert_eq!(created.node_id, loaded.node_id);
         assert_eq!(created.keypair_bytes, loaded.keypair_bytes);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn load_or_create_webrtc_certificate_should_reuse_pem() {
+        let host = memory_host();
+
+        let created = super::load_or_create_webrtc_certificate(&host)
+            .await
+            .expect("create certificate");
+        let loaded = super::load_or_create_webrtc_certificate(&host)
+            .await
+            .expect("reuse certificate");
+
+        assert_eq!(created, loaded);
     }
 
     #[tokio::test]

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -266,6 +266,26 @@ mod tests {
         browser.close().await;
     }
 
+    /// 轮询直到 `native` 的 dialable 地址集出现 webrtc-direct 地址，返回其 certhash 段。
+    async fn wait_for_webrtc_certhash(native: &Endpoint) -> String {
+        let mut addrs = native.watch_addrs();
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                if let Some(hash) = addrs.get().dialable().iter().find_map(|addr| {
+                    let s = addr.to_string();
+                    s.contains("/webrtc-direct/certhash/")
+                        .then(|| s.split("/certhash/").nth(1).map(str::to_owned))
+                        .flatten()
+                }) {
+                    break hash;
+                }
+                addrs.updated().await.expect("address watch closed");
+            }
+        })
+        .await
+        .expect("native profile should publish a webrtc-direct address")
+    }
+
     #[tokio::test]
     async fn native_profile_publishes_webrtc_direct_address() {
         let native = build_endpoint(
@@ -278,22 +298,38 @@ mod tests {
         .await
         .expect("native profile bind");
 
-        let mut addrs = native.watch_addrs();
-        tokio::time::timeout(std::time::Duration::from_secs(10), async {
-            loop {
-                if addrs
-                    .get()
-                    .dialable()
-                    .iter()
-                    .any(|addr| addr.to_string().contains("/webrtc-direct/certhash/"))
-                {
-                    break;
-                }
-                addrs.updated().await.expect("address watch closed");
-            }
-        })
-        .await
-        .expect("native profile should publish a webrtc-direct address");
+        wait_for_webrtc_certhash(&native).await;
         native.close().await;
+    }
+
+    /// 本 PR 修的核心不变量：`identity::load_or_create_webrtc_certificate` 持久化的 PEM
+    /// 经 `build_endpoint` 两次装配后 certhash 必须一致，否则已分发的邀请地址会随每次
+    /// 重启失效。`crates/net/tests/webrtc.rs` 已在 `Endpoint::builder()` 这一层验证过
+    /// 同一 PEM 两次 bind 的 certhash 相等；这里补的是本 PR 新增的 core 集成点——
+    /// `build_endpoint` 的 `webrtc_certificate_pem` 装配路径本身不会漂移。
+    #[tokio::test]
+    async fn build_endpoint_reuses_certhash_for_same_persisted_pem() {
+        let pem = swarmdrop_net::generate_webrtc_certificate_pem().expect("generate cert");
+
+        let mut hashes = Vec::new();
+        for _ in 0..2 {
+            let native = build_endpoint(
+                SecretKey::generate(),
+                Some(pem.clone()),
+                "swarmdrop/test".to_string(),
+                &NetworkRuntimeConfig::default(),
+                EndpointProfile::Native,
+            )
+            .await
+            .expect("native profile bind");
+
+            hashes.push(wait_for_webrtc_certhash(&native).await);
+            native.close().await;
+        }
+
+        assert_eq!(
+            hashes[0], hashes[1],
+            "同一持久化证书经 build_endpoint 两次装配，certhash 必须一致"
+        );
     }
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -78,6 +78,7 @@ impl EndpointProfile {
 )]
 pub async fn start_node<F>(
     secret_key: SecretKey,
+    webrtc_certificate_pem: Option<String>,
     os_info: OsInfo,
     paired_devices: Vec<PairedDeviceInfo>,
     network_config: NetworkRuntimeConfig,
@@ -99,7 +100,14 @@ where
     };
     let agent_version = os_info.to_agent_version();
 
-    let endpoint = build_endpoint(secret_key, agent_version, &network_config, profile).await?;
+    let endpoint = build_endpoint(
+        secret_key,
+        webrtc_certificate_pem,
+        agent_version,
+        &network_config,
+        profile,
+    )
+    .await?;
 
     // 注册引导/中继基础设施节点（DHT bootstrap 依赖至少一个 kad server 进路由表）。
     // 浏览器端无内置引导，整循环跳过。
@@ -184,6 +192,7 @@ pub fn build_router(
 /// 已 bind 的 Endpoint）。identify 协议 / agent_version / DHT server_mode 三端一致。
 async fn build_endpoint(
     secret_key: SecretKey,
+    webrtc_certificate_pem: Option<String>,
     agent_version: String,
     config: &NetworkRuntimeConfig,
     profile: EndpointProfile,
@@ -197,6 +206,10 @@ async fn build_endpoint(
         .identify_protocol(IDENTIFY_PROTOCOL)
         .agent_version(agent_version)
         .dht(dht_config);
+
+    if let Some(pem) = webrtc_certificate_pem {
+        builder = builder.webrtc_certificate(pem);
+    }
 
     builder = match profile {
         EndpointProfile::Native => builder
@@ -232,6 +245,7 @@ mod tests {
 
         let native = build_endpoint(
             SecretKey::generate(),
+            None,
             "swarmdrop/test".to_string(),
             &config,
             EndpointProfile::Native,
@@ -242,6 +256,7 @@ mod tests {
 
         let browser = build_endpoint(
             SecretKey::generate(),
+            None,
             "swarmdrop/test".to_string(),
             &config,
             EndpointProfile::Browser,
@@ -249,5 +264,36 @@ mod tests {
         .await
         .expect("browser profile bind");
         browser.close().await;
+    }
+
+    #[tokio::test]
+    async fn native_profile_publishes_webrtc_direct_address() {
+        let native = build_endpoint(
+            SecretKey::generate(),
+            None,
+            "swarmdrop/test".to_string(),
+            &NetworkRuntimeConfig::default(),
+            EndpointProfile::Native,
+        )
+        .await
+        .expect("native profile bind");
+
+        let mut addrs = native.watch_addrs();
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                if addrs
+                    .get()
+                    .dialable()
+                    .iter()
+                    .any(|addr| addr.to_string().contains("/webrtc-direct/certhash/"))
+                {
+                    break;
+                }
+                addrs.updated().await.expect("address watch closed");
+            }
+        })
+        .await
+        .expect("native profile should publish a webrtc-direct address");
+        native.close().await;
     }
 }

--- a/crates/host/src/ports.rs
+++ b/crates/host/src/ports.rs
@@ -36,6 +36,13 @@ pub trait KeychainProvider: Send + Sync {
     async fn save_identity(&self, identity: DeviceIdentityBytes) -> AppResult<()>;
     async fn delete_identity(&self) -> AppResult<()>;
 
+    /// WebRTC Direct 证书（完整 PEM，含私钥）。
+    ///
+    /// 它与设备 Ed25519 身份分开保存：前者固定分享地址中的 certhash，后者才是
+    /// Noise 握手使用的长期身份。
+    async fn load_webrtc_certificate_pem(&self) -> AppResult<Option<String>>;
+    async fn save_webrtc_certificate_pem(&self, pem: String) -> AppResult<()>;
+
     async fn load_migration_state(&self) -> AppResult<IdentityMigrationState>;
     async fn save_migration_state(&self, state: IdentityMigrationState) -> AppResult<()>;
 

--- a/crates/host/src/ports.rs
+++ b/crates/host/src/ports.rs
@@ -13,11 +13,20 @@ use crate::device::PairedDeviceInfo;
 use crate::error::AppResult;
 
 /// 设备身份密钥材料。
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceIdentityBytes {
     pub keypair: Vec<u8>,
+}
+
+impl std::fmt::Debug for DeviceIdentityBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // 绝不打印密钥材料
+        f.debug_struct("DeviceIdentityBytes")
+            .field("keypair", &"<redacted>")
+            .finish()
+    }
 }
 
 /// 身份存储迁移状态。
@@ -42,6 +51,7 @@ pub trait KeychainProvider: Send + Sync {
     /// Noise 握手使用的长期身份。
     async fn load_webrtc_certificate_pem(&self) -> AppResult<Option<String>>;
     async fn save_webrtc_certificate_pem(&self, pem: String) -> AppResult<()>;
+    async fn delete_webrtc_certificate_pem(&self) -> AppResult<()>;
 
     async fn load_migration_state(&self) -> AppResult<IdentityMigrationState>;
     async fn save_migration_state(&self, state: IdentityMigrationState) -> AppResult<()>;

--- a/crates/net/src/config.rs
+++ b/crates/net/src/config.rs
@@ -74,7 +74,7 @@ impl Default for RelayServerConfig {
 }
 
 /// 内部装配配置（Builder 收集、bind 时消费）。
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct EndpointConfig {
     /// identify 的 protocol_version。默认是中立的内核值——业务协议契约
     /// （如 `/swarmdrop/2.0.0`）由上层经 `Builder::identify_protocol` 显式注入。
@@ -124,5 +124,31 @@ impl Default for EndpointConfig {
             stream_limits: StreamLimits::default(),
             connect_timeout: Duration::from_secs(30),
         }
+    }
+}
+
+impl std::fmt::Debug for EndpointConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EndpointConfig")
+            .field("identify_protocol", &self.identify_protocol)
+            .field("agent_version", &self.agent_version)
+            .field("ping_interval", &self.ping_interval)
+            .field("ping_timeout", &self.ping_timeout)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("dht", &self.dht)
+            .field("mdns", &self.mdns)
+            .field("autonat", &self.autonat)
+            .field("dcutr", &self.dcutr)
+            .field("relay_client", &self.relay_client)
+            .field("relay_server", &self.relay_server)
+            // 绝不打印证书私钥材料，只标注是否已注入持久化证书
+            .field(
+                "webrtc_cert_pem",
+                &self.webrtc_cert_pem.as_ref().map(|_| "<redacted>"),
+            )
+            .field("listen", &self.listen)
+            .field("stream_limits", &self.stream_limits)
+            .field("connect_timeout", &self.connect_timeout)
+            .finish()
     }
 }

--- a/crates/net/src/endpoint/presets.rs
+++ b/crates/net/src/endpoint/presets.rs
@@ -23,6 +23,11 @@ impl Preset for Native {
             "/ip4/0.0.0.0/udp/0/quic-v1"
                 .parse()
                 .expect("valid multiaddr"),
+            // 浏览器到原生端的局域网直连入口。certhash 由持久化 PEM 在 transport
+            // 层补入最终监听地址，邀请会随 dialable 地址集自然携带它。
+            "/ip4/0.0.0.0/udp/0/webrtc-direct"
+                .parse()
+                .expect("valid multiaddr"),
         ];
         // WebSocket listener：同网浏览器的 LAN 直连入口（ws:// 私有 IP 豁免 mixed content，
         // spike 实证）。浏览器拨不了裸 TCP/QUIC，ws 是它够到本机的唯一免证书路径。

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -59,3 +59,13 @@ pub use router::{ProtocolHandler, Router, RouterBuilder};
 pub use rpc::{CallOptions, MAX_RPC_FRAME, Rpc, RpcHandler, RpcMessage, RpcService};
 pub use stream::{Direction, P2pStream, StreamLimits};
 pub use watch::Watcher;
+
+/// 生成可持久化的 WebRTC Direct 证书 PEM（含私钥）。
+///
+/// 调用方必须把完整 PEM 放入安全存储后在每次启动时复用，不能仅保存密钥再重建。
+#[cfg(not(wasm_browser))]
+pub fn generate_webrtc_certificate_pem() -> Result<String, String> {
+    libp2p_webrtc::tokio::Certificate::generate(&mut rand::thread_rng())
+        .map_err(|error| error.to_string())
+        .map(|certificate| certificate.serialize_pem())
+}

--- a/crates/web/src/node.rs
+++ b/crates/web/src/node.rs
@@ -121,6 +121,7 @@ impl WebNode {
         let file_access_for_factory = file_access.clone();
         let started = start_node(
             secret.clone(),
+            None,
             os_info.clone(),
             Vec::new(), // 已配对设备：内存态起步（IndexedDB 持久化属后续工程）
             // LanOnly：浏览器拨不了 TCP/QUIC 内置 bootstrap，跳过它免得 infra 反复空拨刷屏；

--- a/mobile/dev-notes/knowledge/toolchain.md
+++ b/mobile/dev-notes/knowledge/toolchain.md
@@ -390,9 +390,10 @@ build:android`（都带 `--and-generate`）会把 podspec/gradle 引用的手写
 # 1. 先 build 出 host dylib（供 uniffi 提取元数据，本机 target，快）
 cd packages/swarmdrop-core/rust/mobile-core && cargo build
 # 2. 只生成 TS + C++ bindings（library 模式，从 dylib 提取；CWD 需有 Cargo.toml）
+#    dylib 路径见下方「合并进单仓后」的坑——不再是本目录下的 target/debug/
 npx ubrn generate jsi bindings --library \
   --ts-dir ../../src/generated --cpp-dir ../../cpp/generated \
-  --crate swarmdrop_mobile_core target/debug/libswarmdrop_mobile_core.dylib
+  --crate swarmdrop_mobile_core <dylib-path>/libswarmdrop_mobile_core.dylib
 # 3. 需要能真机跑时，再 npx ubrn build ios / android -t arm64-v8a（无 --and-generate，
 #    只重编 Rust + 拷 xcframework/jniLibs，不重生成、不碰脚手架）
 ```
@@ -400,6 +401,31 @@ npx ubrn generate jsi bindings --library \
   RustBuffer 序列化），只有 `src/generated` 的 TS 类型变。diff 应干净、无杂散 churn。
 - `ubrn generate jsi bindings` 在 CWD 跑 `cargo metadata`，必须在 `rust/mobile-core` 目录下跑，
   输出路径写成相对该目录的 `../../{src,cpp}/generated`。
+
+### 合并进单仓后，dylib 产物路径变了——不在 `rust/mobile-core/target/`
+
+上面那条录自 SwarmDrop-RN 还是独立仓库时——那时 `rust/mobile-core` 自己就是 workspace 根，
+`cargo build` 的产物天然落在同目录 `target/debug/`。并入本仓后 `mobile-core` 是**根 Cargo
+workspace 的 member**（`Cargo.toml:workspace.members` 含它，`cargo metadata --no-deps` 的
+`root` 指向仓库根 `Cargo.toml`），`cargo build` 的产物因此落在**仓库根**的 `target/debug/`，
+`rust/mobile-core/target/debug/libswarmdrop_mobile_core.dylib` 根本不存在——照抄旧命令会
+`No such file or directory`。
+
+**正确做法**：
+```bash
+# 在仓库任意位置 build 均可（同一个 workspace target 目录）
+cargo build -p swarmdrop-mobile-core
+cd mobile/packages/swarmdrop-core/rust/mobile-core   # ubrn 仍需在此目录找 Cargo.toml
+<mobile>/node_modules/.bin/ubrn generate jsi bindings --library \
+  --ts-dir ../../src/generated --cpp-dir ../../cpp/generated \
+  --crate swarmdrop_mobile_core /Volumes/yexiyue/SwarmDrop/target/debug/libswarmdrop_mobile_core.dylib
+```
+- `ubrn` 可执行文件也跟着提升到 `mobile/node_modules/.bin/ubrn`（pnpm workspace 提升），
+  不在 `packages/swarmdrop-core/node_modules/`。
+- 找不准路径时 `find /Volumes/yexiyue/SwarmDrop/target/debug -iname "*mobile_core*"` 现查最快。
+
+**相关文件**：`Cargo.toml`（根 workspace members）、
+[packages/swarmdrop-core/rust/mobile-core/Cargo.toml](../../packages/swarmdrop-core/rust/mobile-core/Cargo.toml)
 
 **相关文件**：[packages/swarmdrop-core/ubrn.config.yaml](../../packages/swarmdrop-core/ubrn.config.yaml)
 

--- a/mobile/packages/swarmdrop-core/cpp/generated/swarmdrop_mobile_core.cpp
+++ b/mobile/packages/swarmdrop-core/cpp/generated/swarmdrop_mobile_core.cpp
@@ -235,12 +235,19 @@ extern "C" {
     typedef void
     (*UniffiCallbackInterfaceForeignKeychainProviderMethod5)(
     uint64_t uniffi_handle, 
-    UniffiForeignFutureCompleteRustBuffer uniffi_future_callback, 
+    UniffiForeignFutureCompleteVoid uniffi_future_callback, 
     uint64_t uniffi_callback_data, 
     UniffiForeignFutureDroppedCallbackStruct * uniffi_out_dropped_callback
     );
     typedef void
     (*UniffiCallbackInterfaceForeignKeychainProviderMethod6)(
+    uint64_t uniffi_handle, 
+    UniffiForeignFutureCompleteRustBuffer uniffi_future_callback, 
+    uint64_t uniffi_callback_data, 
+    UniffiForeignFutureDroppedCallbackStruct * uniffi_out_dropped_callback
+    );
+    typedef void
+    (*UniffiCallbackInterfaceForeignKeychainProviderMethod7)(
     uint64_t uniffi_handle, 
     RustBuffer devices_json, 
     UniffiForeignFutureCompleteVoid uniffi_future_callback, 
@@ -268,8 +275,9 @@ extern "C" {
         UniffiCallbackInterfaceForeignKeychainProviderMethod2 delete_identity;
         UniffiCallbackInterfaceForeignKeychainProviderMethod3 load_webrtc_certificate_pem;
         UniffiCallbackInterfaceForeignKeychainProviderMethod4 save_webrtc_certificate_pem;
-        UniffiCallbackInterfaceForeignKeychainProviderMethod5 load_paired_devices_json;
-        UniffiCallbackInterfaceForeignKeychainProviderMethod6 save_paired_devices_json;
+        UniffiCallbackInterfaceForeignKeychainProviderMethod5 delete_webrtc_certificate_pem;
+        UniffiCallbackInterfaceForeignKeychainProviderMethod6 load_paired_devices_json;
+        UniffiCallbackInterfaceForeignKeychainProviderMethod7 save_paired_devices_json;
     } UniffiVTableCallbackInterfaceForeignKeychainProvider;
     /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_clone_mobilecore(
         /*handle*/ uint64_t handle, 
@@ -527,6 +535,9 @@ extern "C" {
     /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(
         /*handle*/ uint64_t ptr, 
         RustBuffer pem
+    );
+    /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem(
+        /*handle*/ uint64_t ptr
     );
     /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_paired_devices_json(
         /*handle*/ uint64_t ptr
@@ -831,6 +842,8 @@ extern "C" {
     uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(
     );
     uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(
+    );
+    uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem(
     );
     uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json(
     );
@@ -4900,7 +4913,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
         rsLambda = nullptr;
     }
 } // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider
-    // Implementation of CallbackInterfaceForeignKeychainProviderMethod5 for vtable field load_paired_devices_json in VTableCallbackInterfaceForeignKeychainProvider
+    // Implementation of CallbackInterfaceForeignKeychainProviderMethod5 for vtable field delete_webrtc_certificate_pem in VTableCallbackInterfaceForeignKeychainProvider
 
 
 // Callback function: uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider::UniffiCallbackInterfaceForeignKeychainProviderMethod5
@@ -4916,6 +4929,144 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
 // We then give the `callback` function pointer to Rust which will call the lambda sometime in the
 // future.
 namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider {
+    using namespace facebook;
+
+    // We need to store a lambda in a global so we can call it from
+    // a function pointer. The function pointer is passed to Rust.
+    static std::function<void(uint64_t, UniffiForeignFutureCompleteVoid, uint64_t, UniffiForeignFutureDroppedCallbackStruct *)> rsLambda = nullptr;
+
+    // This is the main body of the callback. It's called from the lambda,
+    // which itself is called from the callback function which is passed to Rust.
+    static void body(jsi::Runtime &rt,
+                     std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                     std::shared_ptr<jsi::Value> callbackValue
+            ,uint64_t rs_uniffiHandle
+            ,UniffiForeignFutureCompleteVoid rs_uniffiFutureCallback
+            ,uint64_t rs_uniffiCallbackData
+            ,UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+
+        // Convert the arguments from Rust, into jsi::Values.
+        // We'll use the Bridging class to do this…
+        auto js_uniffiHandle = uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_uniffiHandle);
+        auto js_uniffiFutureCallback = uniffi::swarmdrop_mobile_core::Bridging<UniffiForeignFutureCompleteVoid>::toJs(rt, callInvoker, rs_uniffiFutureCallback);
+        auto js_uniffiCallbackData = uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_uniffiCallbackData);
+
+        // Now we are ready to call the callback.
+        // We are already on the JS thread, because this `body` function was
+        // invoked from the CallInvoker.
+        try {
+            // Getting the callback function
+            auto cb = callbackValue->asObject(rt).asFunction(rt);
+            auto uniffiResult = cb.call(rt, js_uniffiHandle, js_uniffiFutureCallback, js_uniffiCallbackData
+            );
+
+            
+
+            
+            // return type is Struct("ForeignFutureDroppedCallbackStruct")
+            // Finally, we need to copy the return value back into the Rust pointer.
+            *rs_uniffiOutDroppedCallback =
+                uniffi::swarmdrop_mobile_core::Bridging<
+                    UniffiForeignFutureDroppedCallbackStruct
+                >::fromJs(
+                    rt, callInvoker, uniffiResult
+                );
+        } catch (const jsi::JSError &error) {
+            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod5: "
+                    << error.what() << std::endl;
+            throw error;
+        }
+    }
+
+    static void callback(uint64_t rs_uniffiHandle, UniffiForeignFutureCompleteVoid rs_uniffiFutureCallback, uint64_t rs_uniffiCallbackData, UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+        // If the runtime has shutdown, then there is no point in trying to
+        // call into Javascript. BUT how do we tell if the runtime has shutdown?
+        //
+        // Answer: the module destructor calls into callback `cleanup` method,
+        // which nulls out the rsLamda.
+        //
+        // If rsLamda is null, then there is no runtime to call into.
+        if (rsLambda == nullptr) {
+            // This only occurs when destructors are calling into Rust free/drop,
+            // which causes the JS callback to be dropped.
+            return;
+        }
+
+        // The runtime, the actual callback jsi::funtion, and the callInvoker
+        // are all in the lambda.
+        rsLambda(
+            rs_uniffiHandle, 
+            rs_uniffiFutureCallback, 
+            rs_uniffiCallbackData, 
+            rs_uniffiOutDroppedCallback);
+    }
+
+    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod5
+    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider
+                    jsi::Runtime &rt,
+                     std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                     const jsi::Value &value) {
+        if (rsLambda != nullptr) {
+            // `makeCallbackFunction` is called in two circumstances:
+            //
+            // 1. at startup, when initializing callback interface vtables.
+            // 2. when polling futures. This happens at least once per future that is
+            //    exposed to Javascript. We know that this is always the same function,
+            //    `uniffiFutureContinuationCallback` in `async-rust-calls.ts`.
+            //
+            // We can therefore return the callback function without making anything
+            // new if we've been initialized already.
+            return callback;
+        }
+        auto callbackFunction = value.asObject(rt).asFunction(rt);
+        auto callbackValue = std::make_shared<jsi::Value>(rt, callbackFunction);
+        rsLambda = [&rt, callInvoker, callbackValue](uint64_t rs_uniffiHandle, UniffiForeignFutureCompleteVoid rs_uniffiFutureCallback, uint64_t rs_uniffiCallbackData, UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+                // We immediately make a lambda which will do the work of transforming the
+                // arguments into JSI values and calling the callback.
+                uniffi_runtime::UniffiCallFunc jsLambda = [
+                    callInvoker,
+                    callbackValue
+                    , rs_uniffiHandle
+                    , rs_uniffiFutureCallback
+                    , rs_uniffiCallbackData
+                    , rs_uniffiOutDroppedCallback](jsi::Runtime &rt) mutable {
+                    body(rt, callInvoker, callbackValue
+                        , rs_uniffiHandle
+                        , rs_uniffiFutureCallback
+                        , rs_uniffiCallbackData
+                        , rs_uniffiOutDroppedCallback);
+                };
+                // We'll then call that lambda from the callInvoker which will
+                // look after calling it on the correct thread.
+                callInvoker->invokeBlocking(rt, jsLambda);
+        };
+        return callback;
+    }
+
+    // This method is called from the destructor of NativeSwarmdropMobileCore, which only happens
+    // when the jsi::Runtime is being destroyed.
+    static void cleanup() {
+        // The lambda holds a reference to the the Runtime, so when this is nulled out,
+        // then the pointer will no longer be left dangling.
+        rsLambda = nullptr;
+    }
+} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider
+    // Implementation of CallbackInterfaceForeignKeychainProviderMethod6 for vtable field load_paired_devices_json in VTableCallbackInterfaceForeignKeychainProvider
+
+
+// Callback function: uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider::UniffiCallbackInterfaceForeignKeychainProviderMethod6
+//
+// We have the following constraints:
+// - we need to pass a function pointer to Rust.
+// - we need a jsi::Runtime and jsi::Function to call into JS.
+// - function pointers can't store state, so we can't use a lamda.
+//
+// For this, we store a lambda as a global, as `rsLambda`. The `callback` function calls
+// the lambda, which itself calls the `body` which then calls into JS.
+//
+// We then give the `callback` function pointer to Rust which will call the lambda sometime in the
+// future.
+namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider {
     using namespace facebook;
 
     // We need to store a lambda in a global so we can call it from
@@ -4959,7 +5110,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
                     rt, callInvoker, uniffiResult
                 );
         } catch (const jsi::JSError &error) {
-            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod5: "
+            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod6: "
                     << error.what() << std::endl;
             throw error;
         }
@@ -4988,8 +5139,8 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
             rs_uniffiOutDroppedCallback);
     }
 
-    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod5
-    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider
+    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod6
+    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider
                     jsi::Runtime &rt,
                      std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
                      const jsi::Value &value) {
@@ -5037,11 +5188,11 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
         // then the pointer will no longer be left dangling.
         rsLambda = nullptr;
     }
-} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider
-    // Implementation of CallbackInterfaceForeignKeychainProviderMethod6 for vtable field save_paired_devices_json in VTableCallbackInterfaceForeignKeychainProvider
+} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider
+    // Implementation of CallbackInterfaceForeignKeychainProviderMethod7 for vtable field save_paired_devices_json in VTableCallbackInterfaceForeignKeychainProvider
 
 
-// Callback function: uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider::UniffiCallbackInterfaceForeignKeychainProviderMethod6
+// Callback function: uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod7::vtablecallbackinterfaceforeignkeychainprovider::UniffiCallbackInterfaceForeignKeychainProviderMethod7
 //
 // We have the following constraints:
 // - we need to pass a function pointer to Rust.
@@ -5053,7 +5204,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
 //
 // We then give the `callback` function pointer to Rust which will call the lambda sometime in the
 // future.
-namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider {
+namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod7::vtablecallbackinterfaceforeignkeychainprovider {
     using namespace facebook;
 
     // We need to store a lambda in a global so we can call it from
@@ -5099,7 +5250,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
                     rt, callInvoker, uniffiResult
                 );
         } catch (const jsi::JSError &error) {
-            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod6: "
+            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod7: "
                     << error.what() << std::endl;
             throw error;
         }
@@ -5129,8 +5280,8 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
             rs_uniffiOutDroppedCallback);
     }
 
-    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod6
-    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider
+    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod7
+    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod7::vtablecallbackinterfaceforeignkeychainprovider
                     jsi::Runtime &rt,
                      std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
                      const jsi::Value &value) {
@@ -5180,7 +5331,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
         // then the pointer will no longer be left dangling.
         rsLambda = nullptr;
     }
-} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider
+} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod7::vtablecallbackinterfaceforeignkeychainprovider
 namespace uniffi::swarmdrop_mobile_core {
 using namespace facebook;
 using CallInvoker = uniffi_runtime::UniffiCallInvoker;
@@ -5223,10 +5374,13 @@ template <> struct Bridging<UniffiVTableCallbackInterfaceForeignKeychainProvider
     rsObject.save_webrtc_certificate_pem = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
           rt, callInvoker, jsObject.getProperty(rt, "save_webrtc_certificate_pem")
         );
-    rsObject.load_paired_devices_json = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
+    rsObject.delete_webrtc_certificate_pem = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
+          rt, callInvoker, jsObject.getProperty(rt, "delete_webrtc_certificate_pem")
+        );
+    rsObject.load_paired_devices_json = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
           rt, callInvoker, jsObject.getProperty(rt, "load_paired_devices_json")
         );
-    rsObject.save_paired_devices_json = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
+    rsObject.save_paired_devices_json = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod7::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
           rt, callInvoker, jsObject.getProperty(rt, "save_paired_devices_json")
         );
 
@@ -5792,6 +5946,14 @@ NativeSwarmdropMobileCore::NativeSwarmdropMobileCore(
         2,
         [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
             return this->cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem"),
+        1,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem(rt, thisVal, args, count);
         }
     );
     props["ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_paired_devices_json"] = jsi::Function::createFromHostFunction(
@@ -6594,6 +6756,14 @@ NativeSwarmdropMobileCore::NativeSwarmdropMobileCore(
             return this->cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(rt, thisVal, args, count);
         }
     );
+    props["ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem(rt, thisVal, args, count);
+        }
+    );
     props["ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json"] = jsi::Function::createFromHostFunction(
         rt,
         jsi::PropNameID::forAscii(rt, "ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json"),
@@ -6796,6 +6966,7 @@ uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermetho
 uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
 uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
 uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
+uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod7::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
 }
 
 // Utility functions for serialization/deserialization of strings.
@@ -7350,6 +7521,13 @@ jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_fn_method
 }
 jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::swarmdrop_mobile_core::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1])
+        );
+
+        
+        return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0])
         );
 
         
@@ -8086,6 +8264,13 @@ jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_checksum_
 }
 jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(
+        );
+
+        
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem(
         );
 
         

--- a/mobile/packages/swarmdrop-core/cpp/generated/swarmdrop_mobile_core.cpp
+++ b/mobile/packages/swarmdrop-core/cpp/generated/swarmdrop_mobile_core.cpp
@@ -227,6 +227,21 @@ extern "C" {
     typedef void
     (*UniffiCallbackInterfaceForeignKeychainProviderMethod4)(
     uint64_t uniffi_handle, 
+    RustBuffer pem, 
+    UniffiForeignFutureCompleteVoid uniffi_future_callback, 
+    uint64_t uniffi_callback_data, 
+    UniffiForeignFutureDroppedCallbackStruct * uniffi_out_dropped_callback
+    );
+    typedef void
+    (*UniffiCallbackInterfaceForeignKeychainProviderMethod5)(
+    uint64_t uniffi_handle, 
+    UniffiForeignFutureCompleteRustBuffer uniffi_future_callback, 
+    uint64_t uniffi_callback_data, 
+    UniffiForeignFutureDroppedCallbackStruct * uniffi_out_dropped_callback
+    );
+    typedef void
+    (*UniffiCallbackInterfaceForeignKeychainProviderMethod6)(
+    uint64_t uniffi_handle, 
     RustBuffer devices_json, 
     UniffiForeignFutureCompleteVoid uniffi_future_callback, 
     uint64_t uniffi_callback_data, 
@@ -251,8 +266,10 @@ extern "C" {
         UniffiCallbackInterfaceForeignKeychainProviderMethod0 load_identity;
         UniffiCallbackInterfaceForeignKeychainProviderMethod1 save_identity;
         UniffiCallbackInterfaceForeignKeychainProviderMethod2 delete_identity;
-        UniffiCallbackInterfaceForeignKeychainProviderMethod3 load_paired_devices_json;
-        UniffiCallbackInterfaceForeignKeychainProviderMethod4 save_paired_devices_json;
+        UniffiCallbackInterfaceForeignKeychainProviderMethod3 load_webrtc_certificate_pem;
+        UniffiCallbackInterfaceForeignKeychainProviderMethod4 save_webrtc_certificate_pem;
+        UniffiCallbackInterfaceForeignKeychainProviderMethod5 load_paired_devices_json;
+        UniffiCallbackInterfaceForeignKeychainProviderMethod6 save_paired_devices_json;
     } UniffiVTableCallbackInterfaceForeignKeychainProvider;
     /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_clone_mobilecore(
         /*handle*/ uint64_t handle, 
@@ -503,6 +520,13 @@ extern "C" {
     );
     /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(
         /*handle*/ uint64_t ptr
+    );
+    /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(
+        /*handle*/ uint64_t ptr
+    );
+    /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(
+        /*handle*/ uint64_t ptr, 
+        RustBuffer pem
     );
     /*handle*/ uint64_t uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_paired_devices_json(
         /*handle*/ uint64_t ptr
@@ -803,6 +827,10 @@ extern "C" {
     uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_identity(
     );
     uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity(
+    );
+    uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(
+    );
+    uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(
     );
     uint16_t uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json(
     );
@@ -4591,7 +4619,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
         rsLambda = nullptr;
     }
 } // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod2::vtablecallbackinterfaceforeignkeychainprovider
-    // Implementation of CallbackInterfaceForeignKeychainProviderMethod3 for vtable field load_paired_devices_json in VTableCallbackInterfaceForeignKeychainProvider
+    // Implementation of CallbackInterfaceForeignKeychainProviderMethod3 for vtable field load_webrtc_certificate_pem in VTableCallbackInterfaceForeignKeychainProvider
 
 
 // Callback function: uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod3::vtablecallbackinterfaceforeignkeychainprovider::UniffiCallbackInterfaceForeignKeychainProviderMethod3
@@ -4729,7 +4757,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
         rsLambda = nullptr;
     }
 } // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod3::vtablecallbackinterfaceforeignkeychainprovider
-    // Implementation of CallbackInterfaceForeignKeychainProviderMethod4 for vtable field save_paired_devices_json in VTableCallbackInterfaceForeignKeychainProvider
+    // Implementation of CallbackInterfaceForeignKeychainProviderMethod4 for vtable field save_webrtc_certificate_pem in VTableCallbackInterfaceForeignKeychainProvider
 
 
 // Callback function: uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider::UniffiCallbackInterfaceForeignKeychainProviderMethod4
@@ -4745,6 +4773,287 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
 // We then give the `callback` function pointer to Rust which will call the lambda sometime in the
 // future.
 namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider {
+    using namespace facebook;
+
+    // We need to store a lambda in a global so we can call it from
+    // a function pointer. The function pointer is passed to Rust.
+    static std::function<void(uint64_t, RustBuffer, UniffiForeignFutureCompleteVoid, uint64_t, UniffiForeignFutureDroppedCallbackStruct *)> rsLambda = nullptr;
+
+    // This is the main body of the callback. It's called from the lambda,
+    // which itself is called from the callback function which is passed to Rust.
+    static void body(jsi::Runtime &rt,
+                     std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                     std::shared_ptr<jsi::Value> callbackValue
+            ,uint64_t rs_uniffiHandle
+            ,RustBuffer rs_pem
+            ,UniffiForeignFutureCompleteVoid rs_uniffiFutureCallback
+            ,uint64_t rs_uniffiCallbackData
+            ,UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+
+        // Convert the arguments from Rust, into jsi::Values.
+        // We'll use the Bridging class to do this…
+        auto js_uniffiHandle = uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_uniffiHandle);
+        auto js_pem = uniffi::swarmdrop_mobile_core::Bridging<RustBuffer>::toJs(rt, callInvoker, rs_pem);
+        auto js_uniffiFutureCallback = uniffi::swarmdrop_mobile_core::Bridging<UniffiForeignFutureCompleteVoid>::toJs(rt, callInvoker, rs_uniffiFutureCallback);
+        auto js_uniffiCallbackData = uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_uniffiCallbackData);
+
+        // Now we are ready to call the callback.
+        // We are already on the JS thread, because this `body` function was
+        // invoked from the CallInvoker.
+        try {
+            // Getting the callback function
+            auto cb = callbackValue->asObject(rt).asFunction(rt);
+            auto uniffiResult = cb.call(rt, js_uniffiHandle, js_pem, js_uniffiFutureCallback, js_uniffiCallbackData
+            );
+
+            
+
+            
+            // return type is Struct("ForeignFutureDroppedCallbackStruct")
+            // Finally, we need to copy the return value back into the Rust pointer.
+            *rs_uniffiOutDroppedCallback =
+                uniffi::swarmdrop_mobile_core::Bridging<
+                    UniffiForeignFutureDroppedCallbackStruct
+                >::fromJs(
+                    rt, callInvoker, uniffiResult
+                );
+        } catch (const jsi::JSError &error) {
+            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod4: "
+                    << error.what() << std::endl;
+            throw error;
+        }
+    }
+
+    static void callback(uint64_t rs_uniffiHandle, RustBuffer rs_pem, UniffiForeignFutureCompleteVoid rs_uniffiFutureCallback, uint64_t rs_uniffiCallbackData, UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+        // If the runtime has shutdown, then there is no point in trying to
+        // call into Javascript. BUT how do we tell if the runtime has shutdown?
+        //
+        // Answer: the module destructor calls into callback `cleanup` method,
+        // which nulls out the rsLamda.
+        //
+        // If rsLamda is null, then there is no runtime to call into.
+        if (rsLambda == nullptr) {
+            // This only occurs when destructors are calling into Rust free/drop,
+            // which causes the JS callback to be dropped.
+            return;
+        }
+
+        // The runtime, the actual callback jsi::funtion, and the callInvoker
+        // are all in the lambda.
+        rsLambda(
+            rs_uniffiHandle, 
+            rs_pem, 
+            rs_uniffiFutureCallback, 
+            rs_uniffiCallbackData, 
+            rs_uniffiOutDroppedCallback);
+    }
+
+    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod4
+    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider
+                    jsi::Runtime &rt,
+                     std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                     const jsi::Value &value) {
+        if (rsLambda != nullptr) {
+            // `makeCallbackFunction` is called in two circumstances:
+            //
+            // 1. at startup, when initializing callback interface vtables.
+            // 2. when polling futures. This happens at least once per future that is
+            //    exposed to Javascript. We know that this is always the same function,
+            //    `uniffiFutureContinuationCallback` in `async-rust-calls.ts`.
+            //
+            // We can therefore return the callback function without making anything
+            // new if we've been initialized already.
+            return callback;
+        }
+        auto callbackFunction = value.asObject(rt).asFunction(rt);
+        auto callbackValue = std::make_shared<jsi::Value>(rt, callbackFunction);
+        rsLambda = [&rt, callInvoker, callbackValue](uint64_t rs_uniffiHandle, RustBuffer rs_pem, UniffiForeignFutureCompleteVoid rs_uniffiFutureCallback, uint64_t rs_uniffiCallbackData, UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+                // We immediately make a lambda which will do the work of transforming the
+                // arguments into JSI values and calling the callback.
+                uniffi_runtime::UniffiCallFunc jsLambda = [
+                    callInvoker,
+                    callbackValue
+                    , rs_uniffiHandle
+                    , rs_pem
+                    , rs_uniffiFutureCallback
+                    , rs_uniffiCallbackData
+                    , rs_uniffiOutDroppedCallback](jsi::Runtime &rt) mutable {
+                    body(rt, callInvoker, callbackValue
+                        , rs_uniffiHandle
+                        , rs_pem
+                        , rs_uniffiFutureCallback
+                        , rs_uniffiCallbackData
+                        , rs_uniffiOutDroppedCallback);
+                };
+                // We'll then call that lambda from the callInvoker which will
+                // look after calling it on the correct thread.
+                callInvoker->invokeBlocking(rt, jsLambda);
+        };
+        return callback;
+    }
+
+    // This method is called from the destructor of NativeSwarmdropMobileCore, which only happens
+    // when the jsi::Runtime is being destroyed.
+    static void cleanup() {
+        // The lambda holds a reference to the the Runtime, so when this is nulled out,
+        // then the pointer will no longer be left dangling.
+        rsLambda = nullptr;
+    }
+} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider
+    // Implementation of CallbackInterfaceForeignKeychainProviderMethod5 for vtable field load_paired_devices_json in VTableCallbackInterfaceForeignKeychainProvider
+
+
+// Callback function: uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider::UniffiCallbackInterfaceForeignKeychainProviderMethod5
+//
+// We have the following constraints:
+// - we need to pass a function pointer to Rust.
+// - we need a jsi::Runtime and jsi::Function to call into JS.
+// - function pointers can't store state, so we can't use a lamda.
+//
+// For this, we store a lambda as a global, as `rsLambda`. The `callback` function calls
+// the lambda, which itself calls the `body` which then calls into JS.
+//
+// We then give the `callback` function pointer to Rust which will call the lambda sometime in the
+// future.
+namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider {
+    using namespace facebook;
+
+    // We need to store a lambda in a global so we can call it from
+    // a function pointer. The function pointer is passed to Rust.
+    static std::function<void(uint64_t, UniffiForeignFutureCompleteRustBuffer, uint64_t, UniffiForeignFutureDroppedCallbackStruct *)> rsLambda = nullptr;
+
+    // This is the main body of the callback. It's called from the lambda,
+    // which itself is called from the callback function which is passed to Rust.
+    static void body(jsi::Runtime &rt,
+                     std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                     std::shared_ptr<jsi::Value> callbackValue
+            ,uint64_t rs_uniffiHandle
+            ,UniffiForeignFutureCompleteRustBuffer rs_uniffiFutureCallback
+            ,uint64_t rs_uniffiCallbackData
+            ,UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+
+        // Convert the arguments from Rust, into jsi::Values.
+        // We'll use the Bridging class to do this…
+        auto js_uniffiHandle = uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_uniffiHandle);
+        auto js_uniffiFutureCallback = uniffi::swarmdrop_mobile_core::Bridging<UniffiForeignFutureCompleteRustBuffer>::toJs(rt, callInvoker, rs_uniffiFutureCallback);
+        auto js_uniffiCallbackData = uniffi_jsi::Bridging<uint64_t>::toJs(rt, callInvoker, rs_uniffiCallbackData);
+
+        // Now we are ready to call the callback.
+        // We are already on the JS thread, because this `body` function was
+        // invoked from the CallInvoker.
+        try {
+            // Getting the callback function
+            auto cb = callbackValue->asObject(rt).asFunction(rt);
+            auto uniffiResult = cb.call(rt, js_uniffiHandle, js_uniffiFutureCallback, js_uniffiCallbackData
+            );
+
+            
+
+            
+            // return type is Struct("ForeignFutureDroppedCallbackStruct")
+            // Finally, we need to copy the return value back into the Rust pointer.
+            *rs_uniffiOutDroppedCallback =
+                uniffi::swarmdrop_mobile_core::Bridging<
+                    UniffiForeignFutureDroppedCallbackStruct
+                >::fromJs(
+                    rt, callInvoker, uniffiResult
+                );
+        } catch (const jsi::JSError &error) {
+            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod5: "
+                    << error.what() << std::endl;
+            throw error;
+        }
+    }
+
+    static void callback(uint64_t rs_uniffiHandle, UniffiForeignFutureCompleteRustBuffer rs_uniffiFutureCallback, uint64_t rs_uniffiCallbackData, UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+        // If the runtime has shutdown, then there is no point in trying to
+        // call into Javascript. BUT how do we tell if the runtime has shutdown?
+        //
+        // Answer: the module destructor calls into callback `cleanup` method,
+        // which nulls out the rsLamda.
+        //
+        // If rsLamda is null, then there is no runtime to call into.
+        if (rsLambda == nullptr) {
+            // This only occurs when destructors are calling into Rust free/drop,
+            // which causes the JS callback to be dropped.
+            return;
+        }
+
+        // The runtime, the actual callback jsi::funtion, and the callInvoker
+        // are all in the lambda.
+        rsLambda(
+            rs_uniffiHandle, 
+            rs_uniffiFutureCallback, 
+            rs_uniffiCallbackData, 
+            rs_uniffiOutDroppedCallback);
+    }
+
+    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod5
+    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider
+                    jsi::Runtime &rt,
+                     std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
+                     const jsi::Value &value) {
+        if (rsLambda != nullptr) {
+            // `makeCallbackFunction` is called in two circumstances:
+            //
+            // 1. at startup, when initializing callback interface vtables.
+            // 2. when polling futures. This happens at least once per future that is
+            //    exposed to Javascript. We know that this is always the same function,
+            //    `uniffiFutureContinuationCallback` in `async-rust-calls.ts`.
+            //
+            // We can therefore return the callback function without making anything
+            // new if we've been initialized already.
+            return callback;
+        }
+        auto callbackFunction = value.asObject(rt).asFunction(rt);
+        auto callbackValue = std::make_shared<jsi::Value>(rt, callbackFunction);
+        rsLambda = [&rt, callInvoker, callbackValue](uint64_t rs_uniffiHandle, UniffiForeignFutureCompleteRustBuffer rs_uniffiFutureCallback, uint64_t rs_uniffiCallbackData, UniffiForeignFutureDroppedCallbackStruct * rs_uniffiOutDroppedCallback) {
+                // We immediately make a lambda which will do the work of transforming the
+                // arguments into JSI values and calling the callback.
+                uniffi_runtime::UniffiCallFunc jsLambda = [
+                    callInvoker,
+                    callbackValue
+                    , rs_uniffiHandle
+                    , rs_uniffiFutureCallback
+                    , rs_uniffiCallbackData
+                    , rs_uniffiOutDroppedCallback](jsi::Runtime &rt) mutable {
+                    body(rt, callInvoker, callbackValue
+                        , rs_uniffiHandle
+                        , rs_uniffiFutureCallback
+                        , rs_uniffiCallbackData
+                        , rs_uniffiOutDroppedCallback);
+                };
+                // We'll then call that lambda from the callInvoker which will
+                // look after calling it on the correct thread.
+                callInvoker->invokeBlocking(rt, jsLambda);
+        };
+        return callback;
+    }
+
+    // This method is called from the destructor of NativeSwarmdropMobileCore, which only happens
+    // when the jsi::Runtime is being destroyed.
+    static void cleanup() {
+        // The lambda holds a reference to the the Runtime, so when this is nulled out,
+        // then the pointer will no longer be left dangling.
+        rsLambda = nullptr;
+    }
+} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider
+    // Implementation of CallbackInterfaceForeignKeychainProviderMethod6 for vtable field save_paired_devices_json in VTableCallbackInterfaceForeignKeychainProvider
+
+
+// Callback function: uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider::UniffiCallbackInterfaceForeignKeychainProviderMethod6
+//
+// We have the following constraints:
+// - we need to pass a function pointer to Rust.
+// - we need a jsi::Runtime and jsi::Function to call into JS.
+// - function pointers can't store state, so we can't use a lamda.
+//
+// For this, we store a lambda as a global, as `rsLambda`. The `callback` function calls
+// the lambda, which itself calls the `body` which then calls into JS.
+//
+// We then give the `callback` function pointer to Rust which will call the lambda sometime in the
+// future.
+namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider {
     using namespace facebook;
 
     // We need to store a lambda in a global so we can call it from
@@ -4790,7 +5099,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
                     rt, callInvoker, uniffiResult
                 );
         } catch (const jsi::JSError &error) {
-            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod4: "
+            std::cout << "Error in callback UniffiCallbackInterfaceForeignKeychainProviderMethod6: "
                     << error.what() << std::endl;
             throw error;
         }
@@ -4820,8 +5129,8 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
             rs_uniffiOutDroppedCallback);
     }
 
-    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod4
-    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider
+    [[maybe_unused]] static UniffiCallbackInterfaceForeignKeychainProviderMethod6
+    makeCallbackFunction( // uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider
                     jsi::Runtime &rt,
                      std::shared_ptr<uniffi_runtime::UniffiCallInvoker> callInvoker,
                      const jsi::Value &value) {
@@ -4871,7 +5180,7 @@ namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainpro
         // then the pointer will no longer be left dangling.
         rsLambda = nullptr;
     }
-} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider
+} // namespace uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider
 namespace uniffi::swarmdrop_mobile_core {
 using namespace facebook;
 using CallInvoker = uniffi_runtime::UniffiCallInvoker;
@@ -4908,10 +5217,16 @@ template <> struct Bridging<UniffiVTableCallbackInterfaceForeignKeychainProvider
     rsObject.delete_identity = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod2::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
           rt, callInvoker, jsObject.getProperty(rt, "delete_identity")
         );
-    rsObject.load_paired_devices_json = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod3::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
+    rsObject.load_webrtc_certificate_pem = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod3::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
+          rt, callInvoker, jsObject.getProperty(rt, "load_webrtc_certificate_pem")
+        );
+    rsObject.save_webrtc_certificate_pem = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
+          rt, callInvoker, jsObject.getProperty(rt, "save_webrtc_certificate_pem")
+        );
+    rsObject.load_paired_devices_json = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
           rt, callInvoker, jsObject.getProperty(rt, "load_paired_devices_json")
         );
-    rsObject.save_paired_devices_json = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
+    rsObject.save_paired_devices_json = uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider::makeCallbackFunction(
           rt, callInvoker, jsObject.getProperty(rt, "save_paired_devices_json")
         );
 
@@ -5461,6 +5776,22 @@ NativeSwarmdropMobileCore::NativeSwarmdropMobileCore(
         1,
         [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
             return this->cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem"),
+        1,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem"),
+        2,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(rt, thisVal, args, count);
         }
     );
     props["ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_paired_devices_json"] = jsi::Function::createFromHostFunction(
@@ -6247,6 +6578,22 @@ NativeSwarmdropMobileCore::NativeSwarmdropMobileCore(
             return this->cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity(rt, thisVal, args, count);
         }
     );
+    props["ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(rt, thisVal, args, count);
+        }
+    );
+    props["ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem"] = jsi::Function::createFromHostFunction(
+        rt,
+        jsi::PropNameID::forAscii(rt, "ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem"),
+        0,
+        [this](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+            return this->cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(rt, thisVal, args, count);
+        }
+    );
     props["ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json"] = jsi::Function::createFromHostFunction(
         rt,
         jsi::PropNameID::forAscii(rt, "ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json"),
@@ -6447,6 +6794,8 @@ uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermetho
 uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod2::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
 uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod3::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
 uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod4::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
+uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod5::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
+uniffi::swarmdrop_mobile_core::cb::callbackinterfaceforeignkeychainprovidermethod6::vtablecallbackinterfaceforeignkeychainprovider::cleanup();
 }
 
 // Utility functions for serialization/deserialization of strings.
@@ -6987,6 +7336,20 @@ jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_fn_method
 }
 jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0])
+        );
+
+        
+        return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0])
+        );
+
+        
+        return uniffi_jsi::Bridging</*handle*/ uint64_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(uniffi_jsi::Bridging</*handle*/ uint64_t>::fromJs(rt, callInvoker, args[0]), uniffi::swarmdrop_mobile_core::Bridging<RustBuffer>::fromJs(rt, callInvoker, args[1])
         );
 
         
@@ -7709,6 +8072,20 @@ jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_checksum_
 }
 jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
         auto value = uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity(
+        );
+
+        
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(
+        );
+
+        
+        return uniffi_jsi::Bridging<uint16_t>::toJs(rt, callInvoker, value);
+}
+jsi::Value NativeSwarmdropMobileCore::cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count) {
+        auto value = uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(
         );
 
         

--- a/mobile/packages/swarmdrop-core/cpp/generated/swarmdrop_mobile_core.hpp
+++ b/mobile/packages/swarmdrop-core/cpp/generated/swarmdrop_mobile_core.hpp
@@ -82,6 +82,8 @@ class NativeSwarmdropMobileCore : public jsi::HostObject {
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_paired_devices_json(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_paired_devices_json(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_ffi_swarmdrop_mobile_core_rust_future_poll_u8(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
@@ -180,6 +182,8 @@ class NativeSwarmdropMobileCore : public jsi::HostObject {
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_constructor_mobilecore_new(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);

--- a/mobile/packages/swarmdrop-core/cpp/generated/swarmdrop_mobile_core.hpp
+++ b/mobile/packages/swarmdrop-core/cpp/generated/swarmdrop_mobile_core.hpp
@@ -84,6 +84,7 @@ class NativeSwarmdropMobileCore : public jsi::HostObject {
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_paired_devices_json(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_paired_devices_json(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_ffi_swarmdrop_mobile_core_rust_future_poll_u8(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
@@ -184,6 +185,7 @@ class NativeSwarmdropMobileCore : public jsi::HostObject {
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
+    jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);
     jsi::Value cpp_uniffi_swarmdrop_mobile_core_checksum_constructor_mobilecore_new(jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count);

--- a/mobile/packages/swarmdrop-core/rust/mobile-core/src/keychain.rs
+++ b/mobile/packages/swarmdrop-core/rust/mobile-core/src/keychain.rs
@@ -19,6 +19,7 @@ pub trait ForeignKeychainProvider: Send + Sync {
     async fn delete_identity(&self) -> Result<(), FfiError>;
     async fn load_webrtc_certificate_pem(&self) -> Result<Option<String>, FfiError>;
     async fn save_webrtc_certificate_pem(&self, pem: String) -> Result<(), FfiError>;
+    async fn delete_webrtc_certificate_pem(&self) -> Result<(), FfiError>;
     async fn load_paired_devices_json(&self) -> Result<String, FfiError>;
     async fn save_paired_devices_json(&self, devices_json: String) -> Result<(), FfiError>;
 }
@@ -64,6 +65,13 @@ impl KeychainProvider for MobileKeychainAdapter {
     async fn save_webrtc_certificate_pem(&self, pem: String) -> AppResult<()> {
         self.foreign
             .save_webrtc_certificate_pem(pem)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn delete_webrtc_certificate_pem(&self) -> AppResult<()> {
+        self.foreign
+            .delete_webrtc_certificate_pem()
             .await
             .map_err(Into::into)
     }

--- a/mobile/packages/swarmdrop-core/rust/mobile-core/src/keychain.rs
+++ b/mobile/packages/swarmdrop-core/rust/mobile-core/src/keychain.rs
@@ -17,6 +17,8 @@ pub trait ForeignKeychainProvider: Send + Sync {
     async fn load_identity(&self) -> Result<Option<Vec<u8>>, FfiError>;
     async fn save_identity(&self, keypair: Vec<u8>) -> Result<(), FfiError>;
     async fn delete_identity(&self) -> Result<(), FfiError>;
+    async fn load_webrtc_certificate_pem(&self) -> Result<Option<String>, FfiError>;
+    async fn save_webrtc_certificate_pem(&self, pem: String) -> Result<(), FfiError>;
     async fn load_paired_devices_json(&self) -> Result<String, FfiError>;
     async fn save_paired_devices_json(&self, devices_json: String) -> Result<(), FfiError>;
 }
@@ -50,6 +52,20 @@ impl KeychainProvider for MobileKeychainAdapter {
 
     async fn delete_identity(&self) -> AppResult<()> {
         self.foreign.delete_identity().await.map_err(Into::into)
+    }
+
+    async fn load_webrtc_certificate_pem(&self) -> AppResult<Option<String>> {
+        self.foreign
+            .load_webrtc_certificate_pem()
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn save_webrtc_certificate_pem(&self, pem: String) -> AppResult<()> {
+        self.foreign
+            .save_webrtc_certificate_pem(pem)
+            .await
+            .map_err(Into::into)
     }
 
     // mobile 没有 Stronghold → keychain 迁移路径,直接返回 Completed

--- a/mobile/packages/swarmdrop-core/rust/mobile-core/src/network.rs
+++ b/mobile/packages/swarmdrop-core/rust/mobile-core/src/network.rs
@@ -1,4 +1,5 @@
 //! 网络生命周期 —— `start_node` / `shutdown_node` / `network_status`。
+
 //!
 //! 节点开关由 host 决定（用户显式控制）；节点运行期间的 presence
 //! （在线宣告 / 已配对设备保活与重连）由 core 自治，host 无需参与。
@@ -196,6 +197,8 @@ impl MobileCore {
         network_config: MobileNetworkRuntimeConfig,
     ) -> FfiResult<()> {
         let keypair = self.ensure_keypair().await?;
+        let webrtc_certificate_pem =
+            swarmdrop_core::identity::load_or_create_webrtc_certificate(self.keychain()).await?;
         let paired_devices = swarmdrop_core::identity::load_paired_devices(self.keychain()).await?;
 
         // 启动前先确保 SQLite 已就绪（断点续传 / 历史记录都依赖它）
@@ -216,6 +219,7 @@ impl MobileCore {
 
         let started = swarmdrop_core::runtime::start_node(
             keypair,
+            Some(webrtc_certificate_pem),
             os_info,
             paired_devices,
             network_config.into(),

--- a/mobile/packages/swarmdrop-core/src/generated/swarmdrop_mobile_core-ffi.ts
+++ b/mobile/packages/swarmdrop-core/src/generated/swarmdrop_mobile_core-ffi.ts
@@ -89,6 +89,8 @@ interface NativeModuleInterface {
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_identity(uniffiSelf: bigint): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_identity(uniffiSelf: bigint, keypair: Uint8Array): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(uniffiSelf: bigint): bigint;
+    ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(uniffiSelf: bigint): bigint;
+    ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(uniffiSelf: bigint, pem: Uint8Array): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_paired_devices_json(uniffiSelf: bigint): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_paired_devices_json(uniffiSelf: bigint, devicesJson: Uint8Array): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_constructor_mobilecore_new(keychain: bigint, eventBus: bigint, fileAccess: bigint, dataDir: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
@@ -141,6 +143,8 @@ interface NativeModuleInterface {
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_identity(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_identity(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity(): number;
+    ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(): number;
+    ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_constructor_mobilecore_new(): number;
@@ -244,7 +248,9 @@ type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod0 = 
 type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod1 = (uniffiHandle: bigint, keypair: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
 type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod2 = (uniffiHandle: bigint, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
 type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod3 = (uniffiHandle: bigint, uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
-type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod4 = (uniffiHandle: bigint, devicesJson: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod4 = (uniffiHandle: bigint, pem: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod5 = (uniffiHandle: bigint, uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod6 = (uniffiHandle: bigint, devicesJson: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
 type UniffiCallbackInterfaceCloneSwarmdropMobileCoreForeignKeychainProvider = (handle: bigint) => UniffiResult<void>;
 type UniffiCallbackInterfaceFreeSwarmdropMobileCoreForeignKeychainProvider = (handle: bigint) => void;
 export type UniffiVTableCallbackInterfaceSwarmdropMobileCoreForeignKeychainProvider = {
@@ -253,8 +259,10 @@ export type UniffiVTableCallbackInterfaceSwarmdropMobileCoreForeignKeychainProvi
   load_identity: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod0;
   save_identity: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod1;
   delete_identity: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod2;
-  load_paired_devices_json: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod3;
-  save_paired_devices_json: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod4;
+  load_webrtc_certificate_pem: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod3;
+  save_webrtc_certificate_pem: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod4;
+  load_paired_devices_json: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod5;
+  save_paired_devices_json: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod6;
 };
 
 // UniffiRustFutureContinuationCallback is generated as part of the component interface's

--- a/mobile/packages/swarmdrop-core/src/generated/swarmdrop_mobile_core-ffi.ts
+++ b/mobile/packages/swarmdrop-core/src/generated/swarmdrop_mobile_core-ffi.ts
@@ -91,6 +91,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(uniffiSelf: bigint): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(uniffiSelf: bigint): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(uniffiSelf: bigint, pem: Uint8Array): bigint;
+    ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem(uniffiSelf: bigint): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_paired_devices_json(uniffiSelf: bigint): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_paired_devices_json(uniffiSelf: bigint, devicesJson: Uint8Array): bigint;
     ubrn_uniffi_swarmdrop_mobile_core_fn_constructor_mobilecore_new(keychain: bigint, eventBus: bigint, fileAccess: bigint, dataDir: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
@@ -145,6 +146,7 @@ interface NativeModuleInterface {
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem(): number;
+    ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json(): number;
     ubrn_uniffi_swarmdrop_mobile_core_checksum_constructor_mobilecore_new(): number;
@@ -249,8 +251,9 @@ type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod1 = 
 type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod2 = (uniffiHandle: bigint, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
 type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod3 = (uniffiHandle: bigint, uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
 type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod4 = (uniffiHandle: bigint, pem: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
-type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod5 = (uniffiHandle: bigint, uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
-type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod6 = (uniffiHandle: bigint, devicesJson: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod5 = (uniffiHandle: bigint, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod6 = (uniffiHandle: bigint, uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod7 = (uniffiHandle: bigint, devicesJson: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
 type UniffiCallbackInterfaceCloneSwarmdropMobileCoreForeignKeychainProvider = (handle: bigint) => UniffiResult<void>;
 type UniffiCallbackInterfaceFreeSwarmdropMobileCoreForeignKeychainProvider = (handle: bigint) => void;
 export type UniffiVTableCallbackInterfaceSwarmdropMobileCoreForeignKeychainProvider = {
@@ -261,8 +264,9 @@ export type UniffiVTableCallbackInterfaceSwarmdropMobileCoreForeignKeychainProvi
   delete_identity: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod2;
   load_webrtc_certificate_pem: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod3;
   save_webrtc_certificate_pem: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod4;
-  load_paired_devices_json: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod5;
-  save_paired_devices_json: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod6;
+  delete_webrtc_certificate_pem: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod5;
+  load_paired_devices_json: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod6;
+  save_paired_devices_json: UniffiCallbackInterfaceSwarmdropMobileCoreForeignKeychainProviderMethod7;
 };
 
 // UniffiRustFutureContinuationCallback is generated as part of the component interface's

--- a/mobile/packages/swarmdrop-core/src/generated/swarmdrop_mobile_core.ts
+++ b/mobile/packages/swarmdrop-core/src/generated/swarmdrop_mobile_core.ts
@@ -4703,6 +4703,8 @@ export interface ForeignKeychainProvider {
     loadIdentity(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<ArrayBuffer | undefined>;
     saveIdentity(keypair: ArrayBuffer, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
     deleteIdentity(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
+    loadWebrtcCertificatePem(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<string | undefined>;
+    saveWebrtcCertificatePem(pem: string, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
     loadPairedDevicesJson(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<string>;
     savePairedDevicesJson(devicesJson: string, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
 }
@@ -4790,6 +4792,65 @@ private constructor(pointer: UniffiHandle) {
             /*rustFutureFunc:*/ () => {
                 return nativeModule().ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_identity(
                     uniffiTypeForeignKeychainProviderImplObjectFactory.clonePointer(this)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_poll_void,
+            /*cancelFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_cancel_void,
+            /*completeFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_complete_void,
+            /*freeFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_free_void,
+            /*liftFunc:*/ (_v) => {},
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeFfiError.lift.bind(FfiConverterTypeFfiError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+    
+    async loadWebrtcCertificatePem(asyncOpts_?: { signal: AbortSignal }): Promise<string | undefined> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_load_webrtc_certificate_pem(
+                    uniffiTypeForeignKeychainProviderImplObjectFactory.clonePointer(this)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_poll_rust_buffer,
+            /*cancelFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_cancel_rust_buffer,
+            /*completeFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_complete_rust_buffer,
+            /*freeFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_free_rust_buffer,
+            // Async returns always go through the JS-side converter: the
+            // FFI symbol returns the future handle (u64), and the user-level
+            // RustBuffer comes back via the shared `rust_future_complete_*`
+            // export. The bytes the runtime hands back must be deserialized
+            // here using the per-callable return-type converter.
+            /*liftFunc:*/ FfiConverterOptionalString.lift.bind(FfiConverterOptionalString),
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeFfiError.lift.bind(FfiConverterTypeFfiError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+    
+    async saveWebrtcCertificatePem(pem: string, asyncOpts_?: { signal: AbortSignal }): Promise<void> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(
+                    uniffiTypeForeignKeychainProviderImplObjectFactory.clonePointer(this),FfiConverterString.lower(pem, nativeModule().rustbuffer_alloc)
                 );
             },
             /*pollFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_poll_void,
@@ -5040,6 +5101,92 @@ const uniffiCallbackInterfaceForeignKeychainProvider: { vtable: any; register: (
             : Promise<void> => {
                 const jsCallback = FfiConverterTypeForeignKeychainProvider.lift(uniffiHandle);
                 return await jsCallback.deleteIdentity({ signal }
+                )
+            };
+            const uniffiHandleSuccess = (returnValue: void) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultVoid */{
+                        call_status: uniffiCaller.createCallStatus()
+                    }
+                );
+            };
+            const uniffiHandleError = (code: number, errorBuf: UniffiByteArray) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultVoid */{
+                        // TODO create callstatus with error.
+                        call_status: uniffiCaller.createErrorStatus(code, errorBuf),
+                    }
+                );
+            };
+            const uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                /*makeCall:*/ uniffiMakeCall,
+                /*handleSuccess:*/ uniffiHandleSuccess,
+                /*handleError:*/ uniffiHandleError,
+                /*isErrorType:*/ FfiError.instanceOf,
+                /*lowerError:*/ FfiConverterTypeFfiError.lower.bind(FfiConverterTypeFfiError),
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
+            );
+            return uniffiForeignFuture;
+        },
+        load_webrtc_certificate_pem: (
+            uniffiHandle: bigint,
+            uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer,
+            uniffiCallbackData: bigint) => {
+            const uniffiMakeCall = 
+            async (signal: AbortSignal)
+            : Promise<string | undefined> => {
+                const jsCallback = FfiConverterTypeForeignKeychainProvider.lift(uniffiHandle);
+                return await jsCallback.loadWebrtcCertificatePem({ signal }
+                )
+            };
+            const uniffiHandleSuccess = (returnValue: string | undefined) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultRustBuffer */{
+                        return_value: FfiConverterOptionalString.lower(returnValue, nativeModule().rustbuffer_alloc),
+                        call_status: uniffiCaller.createCallStatus()
+                    }
+                );
+            };
+            const uniffiHandleError = (code: number, errorBuf: UniffiByteArray) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultRustBuffer */{
+                        return_value: /*empty*/ new Uint8Array(0),
+                        // TODO create callstatus with error.
+                        call_status: uniffiCaller.createErrorStatus(code, errorBuf),
+                    }
+                );
+            };
+            const uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                /*makeCall:*/ uniffiMakeCall,
+                /*handleSuccess:*/ uniffiHandleSuccess,
+                /*handleError:*/ uniffiHandleError,
+                /*isErrorType:*/ FfiError.instanceOf,
+                /*lowerError:*/ FfiConverterTypeFfiError.lower.bind(FfiConverterTypeFfiError),
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
+            );
+            return uniffiForeignFuture;
+        },
+        save_webrtc_certificate_pem: (
+            uniffiHandle: bigint,
+            pem: Uint8Array,
+            uniffiFutureCallback: UniffiForeignFutureCompletevoid,
+            uniffiCallbackData: bigint) => {
+            const uniffiMakeCall = 
+            async (signal: AbortSignal)
+            : Promise<void> => {
+                const jsCallback = FfiConverterTypeForeignKeychainProvider.lift(uniffiHandle);
+                return await jsCallback.saveWebrtcCertificatePem(
+                    FfiConverterString.lift(pem), { signal }
                 )
             };
             const uniffiHandleSuccess = (returnValue: void) => {
@@ -6648,10 +6795,16 @@ function uniffiEnsureInitialized() {
     if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity() !== 39634) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_identity");
     }
-    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json() !== 49293) {
+    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem() !== 61017) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_webrtc_certificate_pem");
+    }
+    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem() !== 57916) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem");
+    }
+    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json() !== 40514) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json");
     }
-    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json() !== 55206) {
+    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json() !== 43512) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json");
     }
     if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_constructor_mobilecore_new() !== 27705) {

--- a/mobile/packages/swarmdrop-core/src/generated/swarmdrop_mobile_core.ts
+++ b/mobile/packages/swarmdrop-core/src/generated/swarmdrop_mobile_core.ts
@@ -4705,6 +4705,7 @@ export interface ForeignKeychainProvider {
     deleteIdentity(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
     loadWebrtcCertificatePem(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<string | undefined>;
     saveWebrtcCertificatePem(pem: string, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
+    deleteWebrtcCertificatePem(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
     loadPairedDevicesJson(asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<string>;
     savePairedDevicesJson(devicesJson: string, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
 }
@@ -4851,6 +4852,33 @@ private constructor(pointer: UniffiHandle) {
             /*rustFutureFunc:*/ () => {
                 return nativeModule().ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_save_webrtc_certificate_pem(
                     uniffiTypeForeignKeychainProviderImplObjectFactory.clonePointer(this),FfiConverterString.lower(pem, nativeModule().rustbuffer_alloc)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_poll_void,
+            /*cancelFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_cancel_void,
+            /*completeFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_complete_void,
+            /*freeFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_free_void,
+            /*liftFunc:*/ (_v) => {},
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeFfiError.lift.bind(FfiConverterTypeFfiError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+    
+    async deleteWebrtcCertificatePem(asyncOpts_?: { signal: AbortSignal }): Promise<void> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().ubrn_uniffi_swarmdrop_mobile_core_fn_method_foreignkeychainprovider_delete_webrtc_certificate_pem(
+                    uniffiTypeForeignKeychainProviderImplObjectFactory.clonePointer(this)
                 );
             },
             /*pollFunc:*/ nativeModule().ubrn_ffi_swarmdrop_mobile_core_rust_future_poll_void,
@@ -5187,6 +5215,47 @@ const uniffiCallbackInterfaceForeignKeychainProvider: { vtable: any; register: (
                 const jsCallback = FfiConverterTypeForeignKeychainProvider.lift(uniffiHandle);
                 return await jsCallback.saveWebrtcCertificatePem(
                     FfiConverterString.lift(pem), { signal }
+                )
+            };
+            const uniffiHandleSuccess = (returnValue: void) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultVoid */{
+                        call_status: uniffiCaller.createCallStatus()
+                    }
+                );
+            };
+            const uniffiHandleError = (code: number, errorBuf: UniffiByteArray) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultVoid */{
+                        // TODO create callstatus with error.
+                        call_status: uniffiCaller.createErrorStatus(code, errorBuf),
+                    }
+                );
+            };
+            const uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                /*makeCall:*/ uniffiMakeCall,
+                /*handleSuccess:*/ uniffiHandleSuccess,
+                /*handleError:*/ uniffiHandleError,
+                /*isErrorType:*/ FfiError.instanceOf,
+                /*lowerError:*/ FfiConverterTypeFfiError.lower.bind(FfiConverterTypeFfiError),
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
+            );
+            return uniffiForeignFuture;
+        },
+        delete_webrtc_certificate_pem: (
+            uniffiHandle: bigint,
+            uniffiFutureCallback: UniffiForeignFutureCompletevoid,
+            uniffiCallbackData: bigint) => {
+            const uniffiMakeCall = 
+            async (signal: AbortSignal)
+            : Promise<void> => {
+                const jsCallback = FfiConverterTypeForeignKeychainProvider.lift(uniffiHandle);
+                return await jsCallback.deleteWebrtcCertificatePem({ signal }
                 )
             };
             const uniffiHandleSuccess = (returnValue: void) => {
@@ -6801,10 +6870,13 @@ function uniffiEnsureInitialized() {
     if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem() !== 57916) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_webrtc_certificate_pem");
     }
-    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json() !== 40514) {
+    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem() !== 31482) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_delete_webrtc_certificate_pem");
+    }
+    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json() !== 16155) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_load_paired_devices_json");
     }
-    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json() !== 43512) {
+    if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json() !== 44226) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_swarmdrop_mobile_core_checksum_method_foreignkeychainprovider_save_paired_devices_json");
     }
     if (nativeModule().ubrn_uniffi_swarmdrop_mobile_core_checksum_constructor_mobilecore_new() !== 27705) {

--- a/mobile/src/core/keychain.ts
+++ b/mobile/src/core/keychain.ts
@@ -3,6 +3,7 @@ import type { ForeignKeychainProvider } from "react-native-swarmdrop-core";
 
 const IDENTITY_KEY = "swarmdrop.identity.keypair";
 const PAIRED_DEVICES_KEY = "swarmdrop.paired-devices";
+const WEBRTC_CERTIFICATE_KEY = "swarmdrop.webrtc-direct.certificate";
 
 export class Keychain implements ForeignKeychainProvider {
   async loadIdentity(): Promise<ArrayBuffer | undefined> {
@@ -16,6 +17,14 @@ export class Keychain implements ForeignKeychainProvider {
 
   async deleteIdentity(): Promise<void> {
     await SecureStore.deleteItemAsync(IDENTITY_KEY);
+  }
+
+  async loadWebrtcCertificatePem(): Promise<string | undefined> {
+    return (await SecureStore.getItemAsync(WEBRTC_CERTIFICATE_KEY)) ?? undefined;
+  }
+
+  async saveWebrtcCertificatePem(pem: string): Promise<void> {
+    await SecureStore.setItemAsync(WEBRTC_CERTIFICATE_KEY, pem);
   }
 
   async loadPairedDevicesJson(): Promise<string> {

--- a/mobile/src/core/keychain.ts
+++ b/mobile/src/core/keychain.ts
@@ -27,6 +27,10 @@ export class Keychain implements ForeignKeychainProvider {
     await SecureStore.setItemAsync(WEBRTC_CERTIFICATE_KEY, pem);
   }
 
+  async deleteWebrtcCertificatePem(): Promise<void> {
+    await SecureStore.deleteItemAsync(WEBRTC_CERTIFICATE_KEY);
+  }
+
   async loadPairedDevicesJson(): Promise<string> {
     return (await SecureStore.getItemAsync(PAIRED_DEVICES_KEY)) ?? "[]";
   }

--- a/openspec/changes/webrtc-direct-reachability/proposal.md
+++ b/openspec/changes/webrtc-direct-reachability/proposal.md
@@ -31,7 +31,7 @@ spike 定的第一道门：**今天浏览器对我们的网络零公网可达入
 ## Impact
 
 - **crates/net**：`config.rs` 的 `webrtc_cert_pem` 保持；`transport.rs` listen 逻辑按地址生效、消 warn。（transport 层已落地，本 change 主要打通配置与 listen 地址。）
-- **crates/core**：`NetworkRuntimeConfig` 增 `webrtc_cert_pem`（或证书来源）字段并透传到 `build_endpoint`；helper/bootstrap 与桌面端点的 listen 地址集加 webrtc-direct 条目。**双 target——进 check-wasm 门禁**（web 拨号侧受益）。
+- **crates/core**：宿主 `KeychainProvider` 读取/首次生成的 `webrtc_cert_pem` 作为独立参数透传到 `build_endpoint`（**不得放入**前端可序列化的 `NetworkRuntimeConfig`）；桌面与移动端点的 listen 地址集已加 webrtc-direct 条目，helper/bootstrap 留待后续 phase。**双 target——进 check-wasm 门禁**（web 拨号侧受益）。
 - **src-tauri / mobile-core**：桌面首启生成 webrtc 证书 → `serialize_pem` 存系统 Keychain；移动端同样存 SecureStore；两端节点都 listen /webrtc-direct。
 - **helper/bootstrap（47.115.172.218）**：持久化证书到服务器数据目录（600）+ listen /webrtc-direct；若把 certhash 硬编码进客户端 bootstrap 配置则**优先长期不轮换**，并预留「经 identify/DHT 动态取 helper certhash」的降级路径（避免换证=全客户端发版的运维刚性）。
 - **crates/invite / pairing**：确认 `shareable_addrs()`/`dialable()` 纳入 webrtc-direct 地址；invite 携带它当 hint（依赖 `pair-invite-protocol`，其 inviter 已是 NodeId + addr hints 形状）。

--- a/openspec/changes/webrtc-direct-reachability/proposal.md
+++ b/openspec/changes/webrtc-direct-reachability/proposal.md
@@ -4,7 +4,7 @@ spike 定的第一道门：**今天浏览器对我们的网络零公网可达入
 
 **大债已付**：libp2p 全家已 pin git rev（`Cargo.toml:51-53`，正是为 webrtc-direct——crates.io `0.9.0-alpha.1` 握手坏、修复在 master）；native webrtc-direct server/dialer 已落地（`crates/net/src/transport.rs:48-65`，M2 接入），wasm webrtc-websys 已接（`:156`），spike 双端 Chrome 实测通过（RTT 400µs）。缺的**不是 transport，是三块收尾**。
 
-用户 2026-07-20 决策：webrtc 要上，做到 **浏览器 ↔ 桌面端点直连**（不止 helper）。
+用户 2026-07-21 决策：webrtc 要上，优先做到 **浏览器 ↔ 同一局域网内的桌面与移动端点直连**（不止 helper）。
 
 三块缺口：
 1. **证书持久化没接通**：`webrtc_cert_pem` 字段（`crates/net/src/config.rs:99`，native only）与 `builder.webrtc_certificate(pem)` setter（`crates/net/src/endpoint/builder.rs:120`）都在，但 core 的 `NetworkRuntimeConfig` 没暴露、`build_endpoint` 从不调 → 默认 `None` → 每次随机 certhash → 已分发地址重启即失效（`transport.rs:54-61` 已 `warn!("certhash addresses will not survive restarts")`）。
@@ -16,7 +16,7 @@ spike 定的第一道门：**今天浏览器对我们的网络零公网可达入
 ## What Changes
 
 - **证书持久化（混合策略核心）**：`webrtc_cert_pem` 从 net `EndpointConfig` 提到 core `NetworkRuntimeConfig`；`build_endpoint` 在需要时调 `.webrtc_certificate(pem)`。桌面 PEM 存 Stronghold/keychain（已有），helper/bootstrap 存服务器数据目录（权限 600）。消掉 `transport.rs` 那条 warn。持久化单位是**整张证书 PEM**（含私钥），不是密钥——certhash=SHA-256(证书 DER)，且 webrtc-rs 每次重建强塞随机 SAN。
-- **listen /webrtc-direct**：桌面端点 + helper/bootstrap 各 listen 一个 `/ip4/../udp/../webrtc-direct` 地址（证书固定 → certhash 固定）。
+- **listen /webrtc-direct**：桌面与移动端点（以及后续 helper/bootstrap）各 listen 一个 `/ip4/../udp/../webrtc-direct` 地址（证书固定 → certhash 固定）。
 - **分享物锚点分离**：invite 长期身份锚点 = `NodeId`（Noise 握手强制）；webrtc-direct/certhash 地址作为**机会主义 hint** 进 addr hints。拨号 `connect(NodeAddr::new(peer))` 先试 hint，失败回落 presence `OnlineRecordLookup` 按 NodeId 从 DHT 重解析当前地址。**绝不据 certhash 做身份判定或授权**（授权在 capability 哈希 + 握手 pin）。
 - **可达性验证**：实证 webrtc-direct/certhash 地址进了 `shareable_addrs()`=`dialable()` 且被 presence announce（未被 loopback/unspecified/circuit 过滤误杀）；实证 wasm 受邀端「hint 失效 → 按 NodeId 重解析」兜底成立。
 - **跨浏览器冒烟**：Chrome 已测，补 Safari / Firefox + https 上下文（`net-kernel.md` 已列为未测组合）。
@@ -32,7 +32,7 @@ spike 定的第一道门：**今天浏览器对我们的网络零公网可达入
 
 - **crates/net**：`config.rs` 的 `webrtc_cert_pem` 保持；`transport.rs` listen 逻辑按地址生效、消 warn。（transport 层已落地，本 change 主要打通配置与 listen 地址。）
 - **crates/core**：`NetworkRuntimeConfig` 增 `webrtc_cert_pem`（或证书来源）字段并透传到 `build_endpoint`；helper/bootstrap 与桌面端点的 listen 地址集加 webrtc-direct 条目。**双 target——进 check-wasm 门禁**（web 拨号侧受益）。
-- **src-tauri**：桌面首启生成 webrtc 证书 → `serialize_pem` 存 keychain/Stronghold → 复用；节点 listen /webrtc-direct。
+- **src-tauri / mobile-core**：桌面首启生成 webrtc 证书 → `serialize_pem` 存系统 Keychain；移动端同样存 SecureStore；两端节点都 listen /webrtc-direct。
 - **helper/bootstrap（47.115.172.218）**：持久化证书到服务器数据目录（600）+ listen /webrtc-direct；若把 certhash 硬编码进客户端 bootstrap 配置则**优先长期不轮换**，并预留「经 identify/DHT 动态取 helper certhash」的降级路径（避免换证=全客户端发版的运维刚性）。
 - **crates/invite / pairing**：确认 `shareable_addrs()`/`dialable()` 纳入 webrtc-direct 地址；invite 携带它当 hint（依赖 `pair-invite-protocol`，其 inviter 已是 NodeId + addr hints 形状）。
 - **回归面**：native 端 webrtc-direct server 持久化证书跨重启 certhash 稳定；presence 重解析链路（`presence/supervisor.rs` dial_backoff + OnlineRecordLookup）在 hint 陈旧时兜底；浏览器↔桌面 + 浏览器↔helper 双路径实拨。

--- a/openspec/changes/webrtc-direct-reachability/tasks.md
+++ b/openspec/changes/webrtc-direct-reachability/tasks.md
@@ -2,21 +2,21 @@
 
 ## Phase 1 — 证书持久化打通（混合策略核心）
 
-- [ ] `NetworkRuntimeConfig`（core `network/config.rs`）增 `webrtc_cert_pem`（或证书来源）字段，透传到 `build_endpoint` → `builder.webrtc_certificate(pem)`
-- [ ] 桌面：首启 `Certificate::generate` → `serialize_pem()` 存 Stronghold/keychain；后续 `from_pem()` 复用
+- [x] 宿主 Keychain 凭据读取后透传到 core `build_endpoint` → `builder.webrtc_certificate(pem)`（不得放入前端可序列化的 `NetworkRuntimeConfig`）
+- [x] 桌面与移动：首启 `Certificate::generate` → `serialize_pem()` 分别存系统 Keychain / SecureStore；后续 `from_pem()` 复用
 - [ ] helper/bootstrap：证书 PEM 持久化到服务器数据目录（权限 600），复用
-- [ ] 消掉 `transport.rs:54-61` 的 `certhash will not survive restarts` warn（有持久化证书时）
-- [ ] 回归：native 端跨重启 certhash 稳定（同一 PEM → 同一 certhash 的断言测试）
+- [x] 有持久化证书时不再触发 `transport.rs:54-61` 的 `certhash will not survive restarts` warn
+- [x] 回归：native 端跨重启 certhash 稳定（同一 PEM → 同一 certhash 的断言测试）
 
 ## Phase 2 — listen /webrtc-direct
 
-- [ ] 桌面端点 listen 地址集加 `/ip4/0.0.0.0/udp/0/webrtc-direct`（+ ipv6）
+- [x] 桌面与移动端点 listen 地址集加 `/ip4/0.0.0.0/udp/0/webrtc-direct`
 - [ ] helper/bootstrap listen /webrtc-direct（证书固定 → certhash 固定）
 - [ ] 实证 listen 生效：本机拨自身 webrtc-direct 地址成功
 
 ## Phase 3 — 分享物锚点分离（NodeId 锚点 + certhash hint）
 
-- [ ] 确认 webrtc-direct/certhash 地址进 `shareable_addrs()` = `dialable()` = `direct_addrs()`，未被 loopback/unspecified/circuit 过滤误杀（D6 覆盖验证）
+- [x] 确认 webrtc-direct/certhash 地址进 `shareable_addrs()` = `dialable()` = `direct_addrs()`，未被 loopback/unspecified/circuit 过滤误杀（D6 覆盖验证）
 - [ ] invite addr hints 携带 webrtc-direct 地址（复用 `pair-invite-protocol`，inviter=NodeId+hints 已就位）
 - [ ] 拨号链路：`connect(NodeAddr::new(peer))` 先试 hint、失败回落 `OnlineRecordLookup` 按 NodeId 重解析（`presence/supervisor.rs` 已实现，验证 webrtc-direct 地址纳入）
 - [ ] 断言：certhash 变更后（换证）按 NodeId 重解析自动拿到新地址，无需重发邀请

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -53,6 +53,9 @@ pub async fn start(
     let file_access_for_factory = file_access.clone();
 
     let device_name = crate::host::device_config::load_device_name(&app).await;
+    let keychain = crate::host::keychain_provider(&app)?;
+    let webrtc_certificate_pem =
+        swarmdrop_core::identity::load_or_create_webrtc_certificate(&*keychain).await?;
     // os_info 由 host 供给：桌面走 `OsInfo::native` 的 env 探测（hostname/os/arch）+ 用户设备名。
     let os_info = OsInfo::native(device_name);
     // custom_bootstrap_nodes 现统一由 network_options 携带（前端 NetworkRuntimeConfig），
@@ -65,6 +68,7 @@ pub async fn start(
 
     let started = swarmdrop_core::runtime::start_node(
         (*secret_key).clone(),
+        Some(webrtc_certificate_pem),
         os_info,
         paired_devices,
         network_config,

--- a/src-tauri/src/host/file_keychain.rs
+++ b/src-tauri/src/host/file_keychain.rs
@@ -126,6 +126,12 @@ impl KeychainProvider for FileKeychainProvider {
         self.write(&file).await
     }
 
+    async fn delete_webrtc_certificate_pem(&self) -> CoreResult<()> {
+        let mut file = self.read().await;
+        file.webrtc_certificate_pem = None;
+        self.write(&file).await
+    }
+
     async fn load_migration_state(&self) -> CoreResult<IdentityMigrationState> {
         // dev 无 Stronghold→keychain 迁移概念，对齐 load_or_create_identity 首次生成即 Completed。
         Ok(IdentityMigrationState::Completed)

--- a/src-tauri/src/host/file_keychain.rs
+++ b/src-tauri/src/host/file_keychain.rs
@@ -26,6 +26,9 @@ struct DevIdentityFile {
     /// protobuf-encoded Ed25519 keypair；空 Vec 视为"无身份"，触发 core 生成新身份。
     #[serde(default)]
     keypair: Vec<u8>,
+    /// dev 模式仍按 release 语义保存完整 PEM，便于验证 certhash 跨重启稳定。
+    #[serde(default)]
+    webrtc_certificate_pem: Option<String>,
     #[serde(default)]
     migration_completed: bool,
     #[serde(default)]
@@ -110,6 +113,16 @@ impl KeychainProvider for FileKeychainProvider {
     async fn delete_identity(&self) -> CoreResult<()> {
         let mut file = self.read().await;
         file.keypair = Vec::new();
+        self.write(&file).await
+    }
+
+    async fn load_webrtc_certificate_pem(&self) -> CoreResult<Option<String>> {
+        Ok(self.read().await.webrtc_certificate_pem)
+    }
+
+    async fn save_webrtc_certificate_pem(&self, pem: String) -> CoreResult<()> {
+        let mut file = self.read().await;
+        file.webrtc_certificate_pem = Some(pem);
         self.write(&file).await
     }
 

--- a/src-tauri/src/host/keychain.rs
+++ b/src-tauri/src/host/keychain.rs
@@ -10,6 +10,7 @@ const SERVICE: &str = "com.yexiyue.swarmdrop";
 const IDENTITY_USER: &str = "device-identity";
 const PAIRED_DEVICES_USER: &str = "paired-devices";
 const MIGRATION_STATE_USER: &str = "identity-migration-state";
+const WEBRTC_CERTIFICATE_USER: &str = "webrtc-direct-certificate";
 
 #[derive(Debug, Clone, Default)]
 pub struct DesktopKeychainProvider;
@@ -41,6 +42,19 @@ impl KeychainProvider for DesktopKeychainProvider {
 
     async fn delete_identity(&self) -> CoreResult<()> {
         run_keyring(|| delete_entry_if_exists(IDENTITY_USER)).await
+    }
+
+    async fn load_webrtc_certificate_pem(&self) -> CoreResult<Option<String>> {
+        run_keyring(|| optional_entry_password(WEBRTC_CERTIFICATE_USER)).await
+    }
+
+    async fn save_webrtc_certificate_pem(&self, pem: String) -> CoreResult<()> {
+        run_keyring(move || {
+            entry(WEBRTC_CERTIFICATE_USER)?
+                .set_password(&pem)
+                .map_err(map_keyring_error)
+        })
+        .await
     }
 
     async fn load_migration_state(&self) -> CoreResult<IdentityMigrationState> {

--- a/src-tauri/src/host/keychain.rs
+++ b/src-tauri/src/host/keychain.rs
@@ -57,6 +57,10 @@ impl KeychainProvider for DesktopKeychainProvider {
         .await
     }
 
+    async fn delete_webrtc_certificate_pem(&self) -> CoreResult<()> {
+        run_keyring(|| delete_entry_if_exists(WEBRTC_CERTIFICATE_USER)).await
+    }
+
     async fn load_migration_state(&self) -> CoreResult<IdentityMigrationState> {
         run_keyring(|| {
             let state = optional_entry_password(MIGRATION_STATE_USER)?;


### PR DESCRIPTION
## Summary

- Enable WebRTC Direct listeners for desktop and mobile endpoints.
- Persist native endpoint certificates in the desktop keychain and mobile SecureStore.
- Refresh the UniFFI bridge and add regression coverage.

## Validation

- cargo check for swarmdrop, swarmdrop-web, and swarmdrop-mobile-core
- mobile typecheck
- WebRTC listener and certificate persistence tests

## Follow-up

This is the native endpoint portion of webrtc-direct-reachability. Helper/bootstrap deployment and live browser-to-device/cross-browser smoke coverage remain tracked in the OpenSpec change.

Note: refreshed UniFFI generated output has generator-produced trailing whitespace because local C++ and Prettier formatters are unavailable.