### PR TITLE
fix(web): 发送记录的对端名不再恒为「web」，顺带收编一份设备名回退副本

### DIFF
--- a/crates/host/src/device.rs
+++ b/crates/host/src/device.rs
@@ -599,6 +599,35 @@ mod tests {
         }
     }
 
+    /// 「name → hostname」这条回退是**三端、收发双向共用**的：接收侧由
+    /// `TransferCtrlService` 落进传输记录，发送侧由各壳（Web 的 `send_files`、桌面/移动的
+    /// 前端）填同一个字段。分叉的表现是同一台设备在「他发给我的」与「我发给他的」两条记录里
+    /// 叫不同的名字，而那种不一致没有任何报错。
+    #[test]
+    fn display_name_prefers_user_set_name_over_hostname() {
+        assert_eq!(
+            sample(Some("书房的 Mac"), "Chrome").display_name(),
+            "书房的 Mac"
+        );
+    }
+
+    /// 空串与纯空白都算「没设」：内核允许传空串清空设备名，之后落成 `Some("")` 还是 `None`
+    /// 取决于路径，这条回退不该被那个差别绊到（前端 `deviceDisplayName` 同义）。
+    #[test]
+    fn display_name_treats_blank_as_unset() {
+        assert_eq!(sample(None, "Chrome").display_name(), "Chrome");
+        assert_eq!(sample(Some(""), "Chrome").display_name(), "Chrome");
+        assert_eq!(sample(Some("  "), "Chrome").display_name(), "Chrome");
+    }
+
+    /// 两级都空时返回空串，**不在这里编一个占位名**——回落到短 PeerId 是展示层的事
+    /// （`@swarmdrop/shared-view` 的 `shortPeerId`）。写死的占位会跟着记录一起落库，
+    /// 将来换措辞、换语言都改不动它。
+    #[test]
+    fn display_name_leaves_the_placeholder_to_the_view_layer() {
+        assert_eq!(sample(None, "").display_name(), "");
+    }
+
     #[test]
     fn device_name_rejects_empty_and_blank() {
         assert_eq!(DeviceName::parse(""), None);

--- a/crates/transfer/src/incoming.rs
+++ b/crates/transfer/src/incoming.rs
@@ -242,7 +242,7 @@ where
                 via_relay,
                 now_ms: chrono::Utc::now().timestamp_millis(),
             });
-            let device_name = display_device_name(&paired_device);
+            let device_name = paired_device.os_info.display_name();
 
             if policy_decision.action == ReceivePolicyAction::Reject {
                 runtime
@@ -357,15 +357,6 @@ where
             Ok(response)
         }
     }
-}
-
-fn display_device_name(device: &PairedDeviceInfo) -> String {
-    device
-        .os_info
-        .name
-        .clone()
-        .filter(|name| !name.trim().is_empty())
-        .unwrap_or_else(|| device.os_info.hostname.clone())
 }
 
 /// transfer 控制面 typed RPC 服务。

--- a/crates/web/src/node.rs
+++ b/crates/web/src/node.rs
@@ -903,10 +903,38 @@ impl WebNode {
 
         let result = self
             .manager
-            .send_offer(&prepared_id, &to, "web", &file_ids, TransferOrigin::Human)
+            .send_offer(
+                &prepared_id,
+                &to,
+                &self.paired_device_name(&to),
+                &file_ids,
+                TransferOrigin::Human,
+            )
             .await
             .map_err(WebError::from)?;
         Ok(result.session_id.to_string())
+    }
+
+    /// 发送记录里存的对端显示名。
+    ///
+    /// 这里曾经是字面量 `"web"`，于是**发出去的每一条记录都叫「web」**——传输页里几行除了
+    /// 时间戳完全同形，同一个文件发两次根本认不出哪条是哪条（而 `peerName` 正是那一行用来
+    /// 回答「发给谁」的唯一字段）。桌面与移动没有这个毛病：它们的 `start_send` /
+    /// `send_prepared` 都由调用方传设备名。
+    ///
+    /// **在 Rust 侧查而不是给 `send_files` 加参数**：查询与规则都与接收侧同源——同一份
+    /// `paired_devices` 表（接收侧经 `PeerDirectory::get_paired_device` 拿，见
+    /// `TransferCtrlService`）、同一个 [`OsInfo::display_name`]。前端手上那个名字是展示层的
+    /// （`organizedDeviceName` 把本机别名也算进去），那是「我怎么称呼它」，不该写进记录。
+    ///
+    /// 查不到时返回空串，回落交给展示层（`peerLabel` → `shortPeerId`）：写死的占位会跟着
+    /// 记录一起落库，将来换措辞、换语言都改不动它。
+    fn paired_device_name(&self, peer_id: &str) -> String {
+        parse_node_id(peer_id)
+            .ok()
+            .and_then(|id| self.net_manager.pairing().get_paired_device(&id))
+            .map(|device| device.os_info.display_name())
+            .unwrap_or_default()
     }
 
     /// 当前挂起（待确认）的入站 offer 列表。

--- a/dev-notes/knowledge/rust-backend.md
+++ b/dev-notes/knowledge/rust-backend.md
@@ -458,7 +458,39 @@ panic `the subtree starting at 16384 contains at most 16384 bytes`。根因是�
   **它不收设备名**——`name` 由 `start_node` 从 `DeviceConfig` 端口填，宿主没有 API 可以注入，这是「本机 OsInfo 只有一个装配点」的编译期保证，不是口头约定。
 - `OsInfo::display_name()`：`name` 去空白后非空则用、否则回退 `hostname`，收敛 UI 显示名的回退语义。
 
-**不要做**：手写 `name.filter(|n| !n.is_empty()).unwrap_or_else(|| hostname.clone())`——仓库里已有几处历史副本（`transfer/incoming.rs` / `mobile events.rs` / `pairing/manager.rs`）对「空串是否回退 / 是否 trim」处理已分叉，是遇到就该收编进 `display_name()` 的技术债，别再添新副本。
+**不要做**：手写 `name.filter(|n| !n.is_empty()).unwrap_or_else(|| hostname.clone())`——遇到就收编进 `display_name()`，别再添新副本。**注意漏 `trim()` 的那种副本是「看起来对」的**：设备名为 `"  "` 时它返回两个空格，而 `display_name()` 回退 hostname，两者只在这一种输入上分叉，没有任何报错。
+
+剩余待收编（2026-08-07 核实）：
+
+| 位置 | 现状 |
+|---|---|
+| `mobile/…/mobile-core/src/events.rs:237` | `!n.is_empty()`，**漏 trim** |
+| `src-tauri/src/mcp/tools.rs:357` | 更远——直接取 `os_info.hostname`（连 `name` 都不看），且找不到设备时把**完整 52 字符 peer_id** 写进 `peer_name` |
+| ~~`crates/transfer/src/incoming.rs`~~ | 已收编（2026-08-07） |
+
+### 落进传输记录的 `peer_name`：一个字段，四个调用点，三种口径（2026-08-07）
+
+`TransferManager::send_offer(…, peer_name, …)` 是三端唯一的发送入口，也是 `peer_name` 列的
+唯一写入者。但**它信任调用方**，于是同一台设备在不同来路下被记成不同的名字：
+
+| 调用点 | 传的是什么 |
+|---|---|
+| `src/routes/_app/send/index.lazy.tsx` | `organizedDeviceName` —— **把本机别名烤进记录** |
+| `src/routes/_app/send/share-target.lazy.tsx` | `deviceDisplayName`（两级） |
+| `mobile/src/app/send/select-device.tsx` | `organizedDeviceName` |
+| `crates/web/src/node.rs` 的 `send_files` | 内核 `OsInfo::display_name()`（2026-08-07 改；**此前是字面量 `"web"`**） |
+
+后果按严重度递增：桌面自己的两条发送路径就不一致；别名改了之后旧记录留着旧别名（别名是
+「我怎么称呼它」，本不该进对端的记录）；而 Web 那个字面量让**发出去的每一条记录都叫「web」**
+——`peerName` 正是列表行里回答「发给谁」的唯一一格，它恒定之后，几行记录除了时间戳完全同形，
+用户报成「传输记录重复展示」。
+
+**接收方向没有这个问题**：它一直是内核在 `incoming.rs` 里派生的，与调用方无关。
+
+更深的做法是**删掉 `peer_name` 参数**，让 `send_offer` 自己经 `PeerDirectory` 派生（接收侧
+现成的那条路），把「收发同名」从注释变成类型保证。代价是 `create_transfer` 在组合根里跑在
+`paired_devices` 装配**之前**（`crates/core/src/runtime.rs`），要么把配对表上提、要么给
+`TransferManager` 做一次晚绑定（`TransferCtrlService` 已有这个形态）。未做。
 
 **更不要做**：`OsInfo::default()`。它产出的是占位主机名，而**需要本机 OsInfo 的地方全在
 `PairingManager` 手上**（`self.os_info`，组合根注入的快照）：`request_pairing` 的

--- a/dev-notes/knowledge/web-app-frontend.md
+++ b/dev-notes/knowledge/web-app-frontend.md
@@ -164,6 +164,27 @@ function SendPanelInner() {
 **相关文件**：`docs/app/app/_components/send-panel.tsx`、
 `docs/app/app/_components/transfer-activity-panel.tsx`、`docs/app/app/_components/panel-fallback.tsx`
 
+#### ⚠️ `pnpm dev` 下这些页面**打不开**，别以为是自己刚写的代码坏了（2026-08-07）
+
+`next dev` 里，读 `useSearchParams()` 的三条路由**永久停在 fallback**：
+`/app/transfer`（「正在读取传输会话…」）、`/app/send`、`/app/inbox`；不读它的
+`/app/devices` 与 `/app/settings` 正常。**`pnpm build` 的静态产物上不复现**。
+
+实测（Next 16.3.0 / React 19.2，干净重启的 dev server，10/10）：
+
+- 与 Fast Refresh 无关——重启 dev server 后第一次访问就是这样
+- 与 query 有无无关——`/app/transfer/?session=abc` 一样卡
+- 页面**不是没渲染**：内容树已经渲染过一遍，被 React 收进 `<div hidden>`（Suspense 的
+  hidden 模式），fallback 盖在上面。所以 `document.querySelector('[data-testid=...]')`
+  找得到元素，`offsetParent` 却是 null——**用 DOM 存在性判断「页面好了」会误判**
+
+根因未定位（不是 `cacheComponents` / `ppr`，`next.config.mjs` 没开）。**手测这三页请用生产
+产物**，跑法同下面「Next Dev Tools 浮标」那节：
+
+```bash
+cd docs && pnpm build && python3 -m http.server 3210 -d out
+```
+
 ## 路由字符串一律走 `_lib/nav.ts`，不在组件里手拼
 
 `nav.ts` 是导航的单一事实源：`NAV.devices` / `NAV.send` … 按 key 索引（写错是编译错误，

--- a/docs/app/app/_components/inbox-views.tsx
+++ b/docs/app/app/_components/inbox-views.tsx
@@ -32,6 +32,7 @@ import { OpenListButton } from "./master-detail";
 import { RelativeTime } from "./relative-time";
 import { StatusDot } from "./status-dot";
 import { WebErrorCard } from "./web-error-view";
+import { peerLabel } from "../_lib/device-presentation";
 import { itemsFromInbox } from "../_lib/file-browser-adapters";
 import { NAV, inboxItemHref, transferSessionHref } from "../_lib/nav";
 import { preferencesActions, usePreferences } from "../_lib/preferences-store";
@@ -221,7 +222,7 @@ export function InboxListRow({
         <span className="flex items-baseline justify-between gap-2 text-[11px] text-muted-foreground">
           <span className="truncate">
             <Trans>
-              来自 {item.sourceName} · {item.itemCount} 个文件 · {formatFileSize(item.totalSize)}
+              来自 {peerLabel(item.sourceName, item.sourcePeerId)} · {item.itemCount} 个文件 · {formatFileSize(item.totalSize)}
             </Trans>
           </span>
           {/* 「什么时候收到的」此前整个收件箱都没有——列表按 receivedAt 倒序排着，
@@ -322,7 +323,7 @@ export function InboxDetailPanel({
           </p>
           <p className="truncate text-xs text-muted-foreground">
             <Trans>
-              来自 {item.sourceName} · {item.itemCount} 个文件 · {formatFileSize(item.totalSize)}
+              来自 {peerLabel(item.sourceName, item.sourcePeerId)} · {item.itemCount} 个文件 · {formatFileSize(item.totalSize)}
             </Trans>
             {" · "}
             <RelativeTime timestamp={item.receivedAt} />

--- a/docs/app/app/_components/incoming-offers-panel.tsx
+++ b/docs/app/app/_components/incoming-offers-panel.tsx
@@ -14,6 +14,7 @@ import { Trans } from "@lingui/react/macro";
 import { formatFileSize } from "@swarmdrop/shared-view";
 import { Button } from "@/components/ui/button";
 import { WebErrorCard } from "./web-error-view";
+import { peerLabel } from "../_lib/device-presentation";
 import { getNode } from "../_lib/node-runtime";
 import { useWebNode, webNodeActions } from "../_lib/store";
 import { useKeyedAsyncAction } from "../_lib/use-keyed-async-action";
@@ -86,7 +87,7 @@ export function IncomingOffersPanel() {
             <li key={offer.sessionId} className="rounded-lg border bg-background px-3 py-2">
               <p className="text-xs text-foreground">
                 <Trans>
-                  <span className="font-medium">{offer.deviceName}</span> 想发送{" "}
+                  <span className="font-medium">{peerLabel(offer.deviceName, offer.peerId)}</span> 想发送{" "}
                   {offer.files.length} 个文件（{formatFileSize(offer.totalSize)}）
                 </Trans>
               </p>

--- a/docs/app/app/_components/transfer-activity-panel.tsx
+++ b/docs/app/app/_components/transfer-activity-panel.tsx
@@ -62,6 +62,7 @@ import { MasterDetail, OpenListButton } from "./master-detail";
 import { SessionTitle } from "./session-title";
 import { TransferDetailPanel } from "./transfer-detail";
 import { NAV, PARAM, transferSessionHref } from "../_lib/nav";
+import { peerLabel } from "../_lib/device-presentation";
 import { getNode } from "../_lib/node-runtime";
 import { useWebNode, webNodeActions } from "../_lib/store";
 import { useAsyncAction } from "../_lib/use-async-action";
@@ -411,6 +412,7 @@ const TransferActivityItem = memo(function TransferActivityItem({
   // 速率只在真的在传时才有意义。其余阶段（等待接受 / 已中断 / 已结束）给时间——
   // 「什么时候的事」在那些阶段正是用户要问的（同桌面 `-session-row.tsx` 的右列）。
   const rate = projection.phase === "active" ? formatTransferRate(live?.speed) : null;
+  const peer = peerLabel(projection.peerName, projection.peerId);
 
   return (
     <li>
@@ -428,7 +430,7 @@ const TransferActivityItem = memo(function TransferActivityItem({
             colorClass={PHASE_META[projection.phase].dot}
             pulse={projection.phase === "active"}
           />
-          <SessionTitle files={projection.files} fallback={projection.peerName} />
+          <SessionTitle files={projection.files} fallback={peer} />
           <span className="shrink-0 text-[11px] text-muted-foreground">{t(phaseLabel(projection))}</span>
         </div>
 
@@ -441,7 +443,7 @@ const TransferActivityItem = memo(function TransferActivityItem({
               role="img"
               aria-label={t(DIRECTION_LABEL[projection.direction])}
             />
-            <span className="truncate">{projection.peerName}</span>
+            <span className="truncate">{peer}</span>
           </span>
           <span className="shrink-0 font-mono tabular-nums">
             {formatFileSize(done)} / {formatFileSize(total)}

--- a/docs/app/app/_components/transfer-detail.tsx
+++ b/docs/app/app/_components/transfer-detail.tsx
@@ -59,6 +59,7 @@ import {
   sessionEndedAt,
   transferSample,
 } from "../_lib/format";
+import { peerLabel } from "../_lib/device-presentation";
 import { itemsFromProjection } from "../_lib/file-browser-adapters";
 import { inboxItemHref } from "../_lib/nav";
 import { getNode } from "../_lib/node-runtime";
@@ -105,6 +106,7 @@ export function TransferDetailPanel({
   // 的纪律对整条进度条依然成立）。逐文件那一路已经不走它了——见下面 `fileItems` 的说明。
   const { live, done, total, percent } = transferSample(projection, liveProgress);
   const DirectionIcon = projection.direction === "send" ? ArrowUpFromLine : ArrowDownToLine;
+  const peer = peerLabel(projection.peerName, projection.peerId);
 
   return (
     // 详情自己是滚动容器（`min-h-0 flex-1` + `overflow-y-auto`）：宽屏下滚详情不会带走
@@ -118,7 +120,7 @@ export function TransferDetailPanel({
               colorClass={PHASE_META[projection.phase].dot}
               pulse={projection.phase === "active"}
             />
-            <SessionTitle files={projection.files} fallback={projection.peerName} />
+            <SessionTitle files={projection.files} fallback={peer} />
           </div>
           <p className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
             <span className="flex items-center gap-1">
@@ -127,7 +129,7 @@ export function TransferDetailPanel({
                 role="img"
                 aria-label={t(DIRECTION_LABEL[projection.direction])}
               />
-              {projection.peerName}
+              {peer}
             </span>
             <span aria-hidden>·</span>
             <span>{t(phaseLabel(projection))}</span>

--- a/docs/app/app/_components/transfer-offer-host.tsx
+++ b/docs/app/app/_components/transfer-offer-host.tsx
@@ -32,6 +32,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { peerLabel } from "../_lib/device-presentation";
 import { itemsFromOffer } from "../_lib/file-browser-adapters";
 import { getNode } from "../_lib/node-runtime";
 import { preferencesActions, usePreferences } from "../_lib/preferences-store";
@@ -98,7 +99,9 @@ export function TransferOfferHost() {
           </DialogTitle>
           <DialogDescription>
             <Trans>
-              <span className="font-medium text-foreground">{current?.deviceName}</span> 想发送{" "}
+              <span className="font-medium text-foreground">
+                {current ? peerLabel(current.deviceName, current.peerId) : ""}
+              </span> 想发送{" "}
               {files.length} 个文件（{formatFileSize(current?.totalSize ?? 0)}）
             </Trans>
           </DialogDescription>

--- a/docs/app/app/_lib/device-presentation.test.ts
+++ b/docs/app/app/_lib/device-presentation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { peerLabel } from "./device-presentation";
+
+const PEER = "12D3KooWP4M1b3qc6tb147qkbEm8fYa7JpcLpGJW4WE2dpK1mJoL";
+
+describe("peerLabel", () => {
+  it("有名字就用名字", () => {
+    expect(peerLabel("MacBook Pro", PEER)).toBe("MacBook Pro");
+  });
+
+  it("名字为空时回落短 PeerId，而不是留白", () => {
+    expect(peerLabel("", PEER)).toBe("12D3…K1mJoL");
+    expect(peerLabel("   ", PEER)).toBe("12D3…K1mJoL");
+  });
+
+  // 跨 wasm 边界的形状类型层保证不了（知识库那条 `.d.ts` 说 string、运行时是别的）。
+  // 五个渲染点共用这一个函数，任何一处 `undefined.trim()` 都会把整页打白。
+  it("名字缺失也不抛", () => {
+    expect(peerLabel(null, PEER)).toBe("12D3…K1mJoL");
+    expect(peerLabel(undefined, PEER)).toBe("12D3…K1mJoL");
+  });
+});

--- a/docs/app/app/_lib/device-presentation.ts
+++ b/docs/app/app/_lib/device-presentation.ts
@@ -9,8 +9,34 @@
 // 文案由 `device-card.tsx` 按同一个枚举值 switch 出 `<Trans>`。
 
 import { Laptop, Monitor, RadioTower, Smartphone, Wifi, Zap, type LucideIcon } from "lucide-react";
-import type { TrustLevel } from "@swarmdrop/shared-view";
+import { shortPeerId, type TrustLevel } from "@swarmdrop/shared-view";
 import type { Device } from "./view-types";
+
+/**
+ * 一条**记录 / 请求**上「对方是谁」那一格的显示名。
+ *
+ * 与 `organizedDeviceName` 的分工：那个用于**设备清单**，读的是当下的 `Device`，还会算上
+ * 本机别名；这个读的是**落库那一刻的名字快照**（传输记录的 `peerName`、收件箱的
+ * `sourceName`、入站 offer 的 `deviceName`），它们都可能是空串——内核的
+ * `OsInfo::display_name()` 在 name 与 hostname 都没有时就返回空，占位归展示层。
+ *
+ * 空着渲染的后果按位置递增：列表里那一格不再回答「发给谁」；收件箱是永久表，空名会一直留着；
+ * 而入站 offer 的确认框会变成「『』想发送 3 个文件」——请用户对一个无名氏的传输做决定。
+ *
+ * 回落用设备页 `organizedDeviceName` 最后一档的**同一个** `shortPeerId`，不另造截断规则；
+ * 不用「未知设备」这类文案——那会让两台无名设备显示成同一行字，比空白更糟。
+ *
+ * `name` 收 `null | undefined` 是因为跨 wasm 边界的形状类型层保证不了
+ * （知识库：`.d.ts` 说 `string`，运行时可能是别的）。这一格现在有五个渲染点共用，
+ * 让其中任何一个因为 `undefined.trim()` 把整页打白不值当。
+ *
+ * ⚠️ **产生空值的是共享内核**，桌面（`-session-row.tsx` / `session-panel.tsx`）与移动
+ * （`history-transfer-row.tsx` 等）的接收方向记录有同一个空值面，目前都是裸渲染。补齐它们时
+ * 这个函数该上移 `@swarmdrop/shared-view`（现在只有一端用，按该包 README 的归属判据 2 不进）。
+ */
+export function peerLabel(name: string | null | undefined, peerId: string): string {
+  return name?.trim() || shortPeerId(peerId);
+}
 
 const OS_ICONS: Record<string, LucideIcon> = {
   windows: Monitor,

--- a/packages/swarmdrop-web/swarmdrop_web.js
+++ b/packages/swarmdrop-web/swarmdrop_web.js
@@ -1913,32 +1913,32 @@ function __wbg_get_imports() {
             return ret;
         }, arguments); },
         __wbindgen_cast_0000000000000001: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 2237, function: Function { arguments: [NamedExternref("MessageEvent")], shim_idx: 2238, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 2235, function: Function { arguments: [NamedExternref("MessageEvent")], shim_idx: 2236, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen_1f3b1eaef9b9ff9e___closure__destroy___dyn_core_7d5f0a2ba6a62c33___ops__function__FnMut__web_sys_ec41cd9da292efe4___features__gen_MessageEvent__MessageEvent____Output_______, wasm_bindgen_1f3b1eaef9b9ff9e___convert__closures_____invoke___web_sys_ec41cd9da292efe4___features__gen_MessageEvent__MessageEvent_____);
             return ret;
         },
         __wbindgen_cast_0000000000000002: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 2237, function: Function { arguments: [NamedExternref("RTCDataChannelEvent")], shim_idx: 2238, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 2235, function: Function { arguments: [NamedExternref("RTCDataChannelEvent")], shim_idx: 2236, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen_1f3b1eaef9b9ff9e___closure__destroy___dyn_core_7d5f0a2ba6a62c33___ops__function__FnMut__web_sys_ec41cd9da292efe4___features__gen_MessageEvent__MessageEvent____Output_______, wasm_bindgen_1f3b1eaef9b9ff9e___convert__closures_____invoke___web_sys_ec41cd9da292efe4___features__gen_MessageEvent__MessageEvent_____);
             return ret;
         },
         __wbindgen_cast_0000000000000003: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 2237, function: Function { arguments: [NamedExternref("RTCPeerConnectionIceEvent")], shim_idx: 2238, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 2235, function: Function { arguments: [NamedExternref("RTCPeerConnectionIceEvent")], shim_idx: 2236, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen_1f3b1eaef9b9ff9e___closure__destroy___dyn_core_7d5f0a2ba6a62c33___ops__function__FnMut__web_sys_ec41cd9da292efe4___features__gen_MessageEvent__MessageEvent____Output_______, wasm_bindgen_1f3b1eaef9b9ff9e___convert__closures_____invoke___web_sys_ec41cd9da292efe4___features__gen_MessageEvent__MessageEvent_____);
             return ret;
         },
         __wbindgen_cast_0000000000000004: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 2366, function: Function { arguments: [], shim_idx: 2367, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 2364, function: Function { arguments: [], shim_idx: 2365, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen_1f3b1eaef9b9ff9e___closure__destroy___dyn_core_7d5f0a2ba6a62c33___ops__function__FnMut_____Output_______, wasm_bindgen_1f3b1eaef9b9ff9e___convert__closures_____invoke______);
             return ret;
         },
         __wbindgen_cast_0000000000000005: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 2917, function: Function { arguments: [Externref], shim_idx: 2918, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 2915, function: Function { arguments: [Externref], shim_idx: 2916, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen_1f3b1eaef9b9ff9e___closure__destroy___dyn_core_7d5f0a2ba6a62c33___ops__function__FnMut__wasm_bindgen_1f3b1eaef9b9ff9e___JsValue____Output_______, wasm_bindgen_1f3b1eaef9b9ff9e___convert__closures_____invoke___wasm_bindgen_1f3b1eaef9b9ff9e___JsValue_____);
             return ret;
         },
         __wbindgen_cast_0000000000000006: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 2971, function: Function { arguments: [], shim_idx: 2972, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 2969, function: Function { arguments: [], shim_idx: 2970, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen_1f3b1eaef9b9ff9e___closure__destroy___dyn_core_7d5f0a2ba6a62c33___ops__function__FnMut_____Output________1_, wasm_bindgen_1f3b1eaef9b9ff9e___convert__closures_____invoke_______1_);
             return ret;
         },


### PR DESCRIPTION
## 起因

「Web 端传输记录会重复展示」。排查后**同 sessionId 的真重复不存在**：store 是按 sessionId 键控的 `Record`、`groupSessions` 的 active/history 两组互斥、IndexedDB 按 session uuid `put_with_key` 覆盖（`load()` 还用 HashMap 再去重一次）、内核生产代码里 `Uuid::new_v4()` 只在 `flow/send.rs:68` 一处、续传复用原 id 不新建。

真正的原因是**几行记录长得一模一样**。起两个独立浏览器 profile 走完配对 + 真实传输（经公网 relay）后，发送端的记录是这样的：

```
repro-blob.bin | 已完成 | web | 195.3 KB / 195.3 KB
```

`WebNode::send_files` 给 `send_offer` 传的 `peer_name` 是**字面量 `"web"`**。而 `peerName` 正是列表行里回答「发给谁」的唯一一格——它恒定之后，发给不同设备的记录彼此无法区分，同一个文件再发一次，两行除了时间戳完全同形。桌面 `start_send` 与移动 `send_prepared` 都由调用方传真实设备名，只有 Web 这一处写死。

## 改动

- **`send_files` 取真实设备名**：按 peerId 查 `PairingManager::get_paired_device`（O(1)，与接收侧 `PeerDirectory` 同一份表）+ `OsInfo::display_name()`。查询与规则都与接收侧同源，同一台设备不会在收发两条记录里叫不同的名字。
  不给 `send_files` 加参数是刻意的：前端手上那个名字是展示层的（`organizedDeviceName` 会把本机别名算进去），那是「我怎么称呼它」，不该写进对端的记录。
- **删掉 `incoming.rs` 手写的 `display_device_name`**：它本就是 `OsInfo::display_name()` 的重复实现，而后者的 doc 明写着"避免各端（transfer / mobile / pairing / web）各手写一份"。审查抓出来的——第一版补丁不但没删它，还把它提升成了 pub 跨 crate 导出。顺带补上 `display_name()` 此前为零的测试覆盖（3 条）。
- **新增 `peerLabel`**（`_lib/device-presentation.ts`）：名字为空时回落 `shortPeerId`，用设备页 `organizedDeviceName` 最后一档的**同一个**函数，不另造截断规则。
  空名不是假想：内核在 `name` 与 `hostname` 都没有时就返回空串（占位归展示层）。接上五个渲染点，其中**入站 offer 确认框最要紧**——原本可能弹出「『』想发送 3 个文件」，请用户对一个无名氏的传输做决定。

## 验证

- 门禁：`cargo check/test --workspace` · `cargo fmt` · `check-wasm.sh`(check + clippy) · `test-wasm.sh`(25) · docs `tsc` · vitest(20 + 根 198) · `check:zustand-access` / `check:clipboard` / `check:shared-view` / `check:landing` · `pnpm build`
- wasm 产物已重建入库
- 端到端：两个浏览器 profile 经公网 relay 配对 + 传输，复现了修前的 `web`；修后的同链路复验受 relay reservation 限流阻塞（与本改动无关），逻辑由单测覆盖

## 已知但未在本 PR 处理

1. **一个字段，四个调用点，三种口径**：桌面 `/send` 传 `organizedDeviceName`（把本机别名烤进记录）、桌面 share-target 传 `deviceDisplayName`、移动传 `organizedDeviceName`、Web 现在是内核派生——桌面自己的两条发送路径就不一致。根治是删掉 `send_offer` 的 `peer_name` 参数、改由内核经 `PeerDirectory` 派生，但要动三端签名与组合根装配顺序（`create_transfer` 跑在 `paired_devices` 之前）。已写进 `rust-backend.md`。
2. **剩余两份设备名回退副本**：`mobile-core/src/events.rs:237`（漏 `trim()`）、`src-tauri/src/mcp/tools.rs:357`（直接取 hostname，且找不到设备时把 52 字符 peer_id 写进 `peer_name`）。同上已记录。
3. **dev 模式下 `/app/transfer`、`/app/send`、`/app/inbox` 永久停在 Suspense fallback**（所有读 `useSearchParams()` 的路由；生产产物不复现，干净 dev server 10/10）。根因未定位，实测边界与手测替代方案已写进 `web-app-frontend.md`。
4. 上一次色彩令牌清扫（#0494a78d）的遗漏：`PHASE_META` 的裸调色板类、`packages/file-browser` 的 `emerald-500`、移动 `--info-ink` 是 sky-800 而非三端约定的 sky-700。
