### PR TITLE
fix(web): 设置页两处视觉杂音——黑色 Multiaddr 胶囊与裸 details 身份行

### DIFF
--- a/dev-notes/knowledge/web-app-frontend.md
+++ b/dev-notes/knowledge/web-app-frontend.md
@@ -957,6 +957,48 @@ python3 -c "import glob,pathlib; s=''.join(pathlib.Path(f).read_text() for f in 
 二维码白卡（含它的 `QrOverlay`）、`appearance-panel.tsx` 的主题预览缩略图（那是在画「主题长什么样」，
 跟着主题变反而错）。新增第三处之前先确认它真属于这一类。
 
+### `bg-foreground` / `text-background` 不是「中性」，是**满对比反色**（2026-08-08）
+
+设置页的「Multiaddr」格式提示曾写作 `bg-foreground` + `text-background`：浅色下一块纯黑、
+深色下一块纯白。它没碰调色板、每个类都是 token，所以在 diff 里完全不可疑——但它是整张页面
+**对比度最高的元素**（约 19:1），而它挂在全页优先级最低的一行（一个收起着的次要动作）上。
+视觉重量与信息重量正好反着。
+
+判据不是「有没有用 token」，而是**这块颜色在本页的对比度排名，和它承载的信息在本页的
+重要度排名，是不是同一名次**。低强调标签走 `Badge variant="outline"`（根 `DESIGN.md` §5 就是
+这么定义 outline/ghost 的）；要跟着所在行一起明暗，加 `text-inherit` 让它继承父行的
+`text-muted-foreground → hover:text-foreground`。
+
+顺带一条计数：那次改动前，同一张设置页有**四种徽标方言**（实心反色 / `bg-primary/10 text-brand`
+的传输名 / `Badge variant="outline"` 的分组计数 / `bg-background/50 border` 的关于页特性片）。
+加第五种之前先在页面里数一遍——徽标是最容易长出方言的一类元素，因为每处都只需要「一个小圆角」。
+
+### 渐进披露一律走 `_components/disclosure.tsx`，不要裸 `<details>`（2026-08-08）
+
+裸 `<details>` 会顶着浏览器默认的 ▶ 三角，那是全站仅有的非 Lucide 图形语汇，且没有 hover、
+没有像样的命中区、展开时也没有方向反馈。`Disclosure` 把 `SectionHeader` 那套披露语汇
+（`ChevronDown` + `group-open:rotate-180` + `--ease-out-quart`）下放到**行**尺度，两档尺寸：
+默认档是设置卡里的一行（`p-4`，与 `SettingsRow` 逐字相同，行高 52px 过触摸基线），
+`compact` 档给弹窗。
+
+三条实现细节，抄这个组件时别丢：
+
+- **marker 要关两次**——`list-none` 管 Chrome/Firefox，`[&::-webkit-details-marker]:hidden`
+  管旧 WebKit。只写一条就会在另一半浏览器上漏出默认三角。
+- **仍然用原生 `<details>`**：键盘、读屏 disclosure 语义、JS 没跑起来也能展开，都是白拿的。
+- **有机器值就摆在收起态右侧**（`value` 属性，恒等宽）。折叠该藏的是「所以呢」那段话，
+  不是答案本身——「身份存在哪里？」此前把一个 API 名藏在一次点击后面，那不是渐进披露。
+
+### 通栏行的焦点环要用**负** `outline-offset`（2026-08-08）
+
+`.focus-ring` 的 `outline-offset: 2px` 是给独立控件用的。**通栏行**（`SettingsCard` 里的
+`SettingsRow` / `Disclosure`、`ConnectionPanel` 的「添加自定义引导节点」）两侧紧贴容器边缘，
+而这些容器都是 `overflow-hidden`——往外 2px 的环左右两段会被整段裁掉，只剩上下两条横线，
+看起来像渲染坏了。
+
+修法是在该行上加 `focus-visible:-outline-offset-2`：同一个环、同一种颜色宽度，只把偏移翻个号，
+不动全局的 `.focus-ring`（utilities 层排在 components 之后，能干净地覆盖）。
+
 ## `scrollbar-gutter: stable` 会在应用区右边留一条永远空的死边
 
 `global.css` 里 `html { scrollbar-gutter: stable }` 是给**文档站**的：长短不一的文档页之间

--- a/docs/app/app/_components/connection-panel.tsx
+++ b/docs/app/app/_components/connection-panel.tsx
@@ -353,7 +353,10 @@ export function ConnectionPanel() {
             type="button"
             onClick={() => setShowInput(true)}
             disabled={!ready}
-            className="focus-ring flex w-full items-center justify-between gap-3 border-b p-4 text-sm text-muted-foreground transition-colors last:border-b-0 hover:bg-accent/40 hover:text-foreground disabled:opacity-50"
+            // `focus-visible:-outline-offset-2`：这一行是通栏的，两侧紧贴 `SettingsCard`
+            // 的边缘，而那张卡是 `overflow-hidden`——`.focus-ring` 往外 2px 的环左右两段
+            // 会被整段裁掉，只剩上下两条横线。同一个环，只把偏移翻个号。
+            className="focus-ring flex w-full items-center justify-between gap-3 border-b p-4 text-sm text-muted-foreground transition-colors last:border-b-0 hover:bg-accent/40 hover:text-foreground focus-visible:-outline-offset-2 disabled:opacity-50"
           >
             <span className="flex min-w-0 items-center gap-2">
               <Plus className="size-4 shrink-0" aria-hidden />

--- a/docs/app/app/_components/connection-panel.tsx
+++ b/docs/app/app/_components/connection-panel.tsx
@@ -359,9 +359,21 @@ export function ConnectionPanel() {
               <Plus className="size-4 shrink-0" aria-hidden />
               <Trans>添加自定义引导节点</Trans>
             </span>
-            <span className="shrink-0 rounded-full bg-foreground px-2.5 py-1 text-[11px] font-medium text-background">
+            {/*
+              输入格式提示。**曾经是 `bg-foreground` + `text-background` 的实心胶囊**——
+              浅色下一块纯黑、深色下一块纯白，是整张设置页对比度最高的元素，却挂在
+              全页优先级最低的一行（一个收起着的次要动作）上。视觉重量与信息重量正好反着，
+              而且它是这一页第四种徽标方言：同一个面板里的传输名用 `bg-primary/10 text-brand`，
+              分组标题旁的计数用 `Badge variant="outline"`。
+
+              改成 shared `Badge` 的 outline 档——DESIGN.md §5 把 outline/ghost 定义为
+              「低强调标签」，这正是一个。`text-inherit` 让它跟着整行的
+              `text-muted-foreground → hover:text-foreground` 一起走，
+              于是这一行读起来是一个整体，而不是一行灰字外加一块黑砖。
+            */}
+            <Badge variant="outline" className="text-[10px] text-inherit">
               Multiaddr
-            </span>
+            </Badge>
           </button>
         )}
 

--- a/docs/app/app/_components/disclosure.tsx
+++ b/docs/app/app/_components/disclosure.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+// 行尺度的渐进披露：收起时是「标题 +（可选）机器值」，展开露出解释。
+//
+// ## 为什么要有这个文件
+//
+// 此前应用区有两处各自手搓的 `<details>`——设置页的「身份存储」与节点弹窗的「网络诊断」，
+// 两处都直接用浏览器默认的 ▶ 三角标记。那是整个产品里仅有的两处非 Lucide 图形语汇，
+// 既没有 hover、没有像样的命中区，也没有展开时的方向反馈，看起来像还没写完的 HTML。
+//
+// 应用区本来就有一套披露语汇（`section.tsx` 的 `SectionHeader`：`ChevronDown` + 180° 旋转
+// + ease-out-quart），缺的只是它在**行**这个尺度上的对应物。两处各写各的正是「缺基元」的
+// 典型症状，所以修法是补基元而不是分别调样式。
+//
+// ## 仍然用原生 `<details>`
+//
+// 键盘操作、读屏的 disclosure 语义、以及「JS 没跑起来也能展开」都是白拿的，换成 React state
+// 一样也换不来。只把 marker 关掉、自己画箭头——`list-none` 管 Chrome/Firefox，
+// `::-webkit-details-marker` 管旧 WebKit，两条缺一个就会漏出默认三角。
+//
+// ## 两档尺寸
+//
+// 默认档是**设置卡里的一行**：`p-4` 与 `SettingsRow` 逐字相同，整行可点、hover 有底色。
+// `compact` 档给弹窗等空间紧张处：字号降到 11–12px、不铺 hover 底色（它外面通常套着一个
+// 圆角边框盒，铺底色要么被裁要么盖住圆角，为一处诊断入口不值得）。
+
+import { ChevronDown } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+export function Disclosure({
+  label,
+  value,
+  children,
+  compact = false,
+  className,
+}: {
+  /** 收起态的标题。**用名词短语**，与卡里其余标签（设备名 / 节点 ID / 可达地址）同一种口吻。 */
+  label: ReactNode;
+  /**
+   * 收起时就摆在右侧的机器值——有它的话用户不点开也拿得到答案，折叠起来的就只剩「所以呢」。
+   * 按 Mono Truth Rule 恒为等宽，所以**只传字面值**（ID、路径、API 名），别传散文。
+   */
+  value?: ReactNode;
+  children: ReactNode;
+  /** 紧凑档：见文件头。 */
+  compact?: boolean;
+  className?: string;
+}) {
+  return (
+    <details className={cn("group", className)}>
+      <summary
+        className={cn(
+          "focus-ring flex cursor-pointer list-none items-center gap-3 transition-colors [&::-webkit-details-marker]:hidden",
+          // 焦点环**画在里面**。`.focus-ring` 的 `outline-offset: 2px` 是给独立控件用的，
+          // 而这一行是通栏的：它两侧紧贴容器边缘，而容器（`SettingsCard` / 这里的圆角边框盒）
+          // 都是 `overflow-hidden`，往外 2px 的环左右两段会被整段裁掉，只剩上下两条横线。
+          // 同一个环、同一种颜色宽度，只把偏移翻个号。
+          "focus-visible:-outline-offset-2",
+          // 底色定在 summary 上、只有标题单独提亮，是为了让**箭头与值跟着整行走**：
+          // compact 档的 hover 反馈是提亮文字，箭头若自带 `text-muted-foreground`，
+          // 就会出现「标题亮了、箭头没亮」的半截反馈。
+          "text-muted-foreground",
+          compact ? "px-3 py-2.5 text-xs hover:text-foreground" : "p-4 text-sm hover:bg-accent/40",
+        )}
+      >
+        <span className={cn("shrink-0 font-medium", !compact && "text-foreground")}>{label}</span>
+        {/* 没有 value 时这个 span 是空的，但 `flex-1` 仍然把箭头顶到右边——
+            省掉一个「有没有 value」的分支。 */}
+        <span className="min-w-0 flex-1 truncate text-right font-mono text-xs">{value}</span>
+        <ChevronDown
+          className="size-4 shrink-0 transition-transform duration-200 ease-[var(--ease-out-quart)] group-open:rotate-180 motion-reduce:transition-none"
+          aria-hidden
+        />
+      </summary>
+      <div className={cn(compact ? "px-3 pb-2.5" : "px-4 pb-4")}>{children}</div>
+    </details>
+  );
+}

--- a/docs/app/app/_components/node-panel.tsx
+++ b/docs/app/app/_components/node-panel.tsx
@@ -45,6 +45,7 @@ import { renameDevice } from "../_lib/node-runtime";
 import { IDENTITY_LOCATION, selectReservation, useWebNode, webNodeActions } from "../_lib/store";
 import { useAsyncAction } from "../_lib/use-async-action";
 import { useCopyToClipboard } from "../_lib/use-copy";
+import { Disclosure } from "./disclosure";
 import { NodeStatusDialog } from "./node-status-dialog";
 import { SettingsCard, SettingsSection } from "./settings-primitives";
 import { WebErrorCard } from "./web-error-view";
@@ -264,16 +265,22 @@ export function NodePanel() {
         </div>
 
         {/* 「身份存在哪儿」是**诊断**不是设置：它回答的是「我刷新后还是我吗」。
-            这条是 Web 独有的（另外两端的身份在系统钥匙串里，没有这个疑问）。 */}
-        <details className="border-t px-4 py-2.5 text-xs">
-          <summary className="focus-ring cursor-pointer rounded text-muted-foreground">
-            <Trans>身份存在哪里？</Trans>
-          </summary>
-          <p className="mt-2 text-muted-foreground">
-            <span className="font-mono">{t(IDENTITY_LOCATION)}</span>{" "}
-            <Trans>· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。</Trans>
+            这条是 Web 独有的（另外两端的身份在系统钥匙串里，没有这个疑问）。
+
+            两处与此前不同，都不是为了好看：
+
+            · **标题是名词短语，答案摆在收起态的右边。** 原来它是一句问句
+              「身份存在哪里？」——这张卡上唯一的疑问式标签——而答案只是一个 API 名，
+              却非点开不可。折叠该藏的是**后果**（清掉浏览器数据会换身份），
+              那才是需要一段话的部分；一个词不该收门票。
+            · **走 `Disclosure` 而不是裸 `<details>`。** 裸的那版顶着浏览器默认的 ▶，
+              命中区只有那行 12px 文字高，且 `py-2.5` 比上面的指标条还窄，
+              整张卡的下缘看着像少写了点什么。理由见 disclosure.tsx 的文件头。 */}
+        <Disclosure className="border-t" label={<Trans>身份存储</Trans>} value={IDENTITY_LOCATION}>
+          <p className="text-xs leading-5 text-muted-foreground">
+            <Trans>刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。</Trans>
           </p>
-        </details>
+        </Disclosure>
       </SettingsCard>
     </SettingsSection>
   );

--- a/docs/app/app/_components/node-status-dialog.tsx
+++ b/docs/app/app/_components/node-status-dialog.tsx
@@ -43,6 +43,7 @@ import { selectReservation, useWebNode } from "../_lib/store";
 import { useAsyncAction } from "../_lib/use-async-action";
 import { useNowSeconds } from "../_lib/use-now-seconds";
 import { CopyButton } from "./copy-button";
+import { Disclosure } from "./disclosure";
 import { NodeStatusPill, useNodeStatusLabel } from "./node-status-pill";
 import { StartNodeButton } from "./start-node-button";
 import { WebErrorCard } from "./web-error-view";
@@ -172,11 +173,8 @@ function NodeStatusDialogContent() {
               还是我吗」，属于持久身份，归设置页的「本机节点」区（那里同时管改名）。
               节点 ID 两处都有则是刻意的：它是排查时最常要复制的一串，三端的节点弹窗都带。
             */}
-            <details className="rounded-lg border px-3 py-2 text-xs">
-              <summary className="focus-ring -mx-1 cursor-pointer rounded px-1 text-muted-foreground">
-                <Trans>网络诊断</Trans>
-              </summary>
-              <dl className="mt-2 flex flex-col gap-2.5">
+            <Disclosure compact className="rounded-lg border text-xs" label={<Trans>网络诊断</Trans>}>
+              <dl className="flex flex-col gap-2.5">
                 <DiagnosticRow label={<Trans>节点 ID</Trans>}>
                   <span className="min-w-0 flex-1 font-mono tabular-nums break-all">
                     {nodeId ?? "—"}
@@ -207,7 +205,7 @@ function NodeStatusDialogContent() {
                   的「引导节点」区。
                 </Trans>
               </p>
-            </details>
+            </Disclosure>
           </>
         )}
       </div>

--- a/docs/app/app/_lib/store.ts
+++ b/docs/app/app/_lib/store.ts
@@ -7,7 +7,6 @@
 //         `inboxItems` 域的注释；拉取时机由 InboxPanel 自己掌握）。
 // 四者都汇入本 store。actions 独立于 state（不塞进 state 对象），保证 selector 快照稳定。
 
-import { msg } from "@lingui/core/macro";
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 import { isActiveSession } from "./format";
@@ -37,9 +36,16 @@ const EVENT_LOG_CAP = 50;
 /**
  * 身份持久化位置。当前基座只支持主线程 Window 运行（`spawnNode` 未提供 Worker 路径，
  * `WebNode::spawn` 也要求主线程——见 node-runtime.ts 注释），故这是编译期常量，不是探测值；
- * Worker 模式落地时（对应 OPFS）需改为按运行环境派生。
+ * Worker 模式落地时（对应 OPFS）把这里换成按运行环境派生即可。
+ *
+ * **它是 API 名，所以是裸字符串而不是 `msg`**：`localStorage` 在任何语言里都写作
+ * `localStorage`，进 catalog 只会得到三份一模一样的条目。此前它是
+ * `msg\`localStorage（Window 主线程）\`` —— 那个括号里的中文限定语与 API 名黏在同一个
+ * 串里，界面上整串套 `font-mono`，CJK 落回非等宽字体、字距还被撑开，跟紧随其后的正文
+ * 明显不是一套字（Mono Truth Rule 只管字面值，不管散文）。限定语现在只留在这条注释里：
+ * 今天没有 Worker 模式，「主线程」对用户不构成可据以行动的信息。
  */
-export const IDENTITY_LOCATION = msg`localStorage（Window 主线程）`;
+export const IDENTITY_LOCATION = "localStorage";
 
 /**
  * 接收面板所需的稳定 offer 视图。

--- a/docs/app/app/_locales/en/messages.po
+++ b/docs/app/app/_locales/en/messages.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: app/app/_components/node-panel.tsx
-msgid "· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
-msgstr "· Survives a page refresh. Clearing browser data gives this device a new identity, and paired devices will need to pair again."
+#~ msgid "· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
+#~ msgstr "· Survives a page refresh. Clearing browser data gives this device a new identity, and paired devices will need to pair again."
 
 #: app/app/_components/node-panel.tsx
 msgid "（浏览器默认）"
@@ -143,8 +143,8 @@ msgid "circuit 已撤销，对方扫这个码也拨不回来。重新建立可�
 msgstr "The circuit was dropped, so scanning this code can no longer reach you. Re-establish reachability, then generate a new invite."
 
 #: app/app/_lib/store.ts
-msgid "localStorage（Window 主线程）"
-msgstr "localStorage (main window thread)"
+#~ msgid "localStorage（Window 主线程）"
+#~ msgstr "localStorage (main window thread)"
 
 #: app/app/_components/app-nav.tsx
 msgid "SwarmDrop 官网首页"
@@ -415,6 +415,10 @@ msgstr "Aliases and groups stay on this device. They are never synced to the oth
 #: app/app/_components/transfer-activity-panel.tsx
 msgid "到设备页点某台在线设备的「发送」，传输开始后会实时出现在这里。"
 msgstr "Hit Send on an online device, and the transfer shows up here live."
+
+#: app/app/_components/node-panel.tsx
+msgid "刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
+msgstr "Survives a page refresh. Clearing browser data gives this device a new identity, and paired devices will need to pair again."
 
 #: app/app/_components/pairing-panel.tsx
 msgid "刷新页面后它可能恢复可用，建议稍后再撤销一次。"
@@ -1627,8 +1631,12 @@ msgid "跟随系统"
 msgstr "System"
 
 #: app/app/_components/node-panel.tsx
-msgid "身份存在哪里？"
-msgstr "Where is this identity stored?"
+msgid "身份存储"
+msgstr "Identity storage"
+
+#: app/app/_components/node-panel.tsx
+#~ msgid "身份存在哪里？"
+#~ msgstr "Where is this identity stored?"
 
 #: app/app/_lib/view-types.ts
 msgid "身份错误"

--- a/docs/app/app/_locales/zh-TW/messages.po
+++ b/docs/app/app/_locales/zh-TW/messages.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: app/app/_components/node-panel.tsx
-msgid "· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
-msgstr "· 重新整理後保持不變。清除瀏覽器資料會讓本機換一個新身分，已配對的裝置需要重新配對。"
+#~ msgid "· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
+#~ msgstr "· 重新整理後保持不變。清除瀏覽器資料會讓本機換一個新身分，已配對的裝置需要重新配對。"
 
 #: app/app/_components/node-panel.tsx
 msgid "（浏览器默认）"
@@ -143,8 +143,8 @@ msgid "circuit 已撤销，对方扫这个码也拨不回来。重新建立可�
 msgstr "circuit 已撤銷，對方掃這個碼也連不回來。重新建立可連線狀態後請重新產生。"
 
 #: app/app/_lib/store.ts
-msgid "localStorage（Window 主线程）"
-msgstr "localStorage（Window 主執行緒）"
+#~ msgid "localStorage（Window 主线程）"
+#~ msgstr "localStorage（Window 主執行緒）"
 
 #: app/app/_components/app-nav.tsx
 msgid "SwarmDrop 官网首页"
@@ -415,6 +415,10 @@ msgstr "別名與群組只存在本機，不會同步給對方，也不會改變
 #: app/app/_components/transfer-activity-panel.tsx
 msgid "到设备页点某台在线设备的「发送」，传输开始后会实时出现在这里。"
 msgstr "到裝置頁點某台在線裝置的「傳送」，傳輸開始後會即時出現在這裡。"
+
+#: app/app/_components/node-panel.tsx
+msgid "刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
+msgstr "重新整理後保持不變。清除瀏覽器資料會讓本機換一個新身分，已配對的裝置需要重新配對。"
 
 #: app/app/_components/pairing-panel.tsx
 msgid "刷新页面后它可能恢复可用，建议稍后再撤销一次。"
@@ -1627,8 +1631,12 @@ msgid "跟随系统"
 msgstr "跟隨系統"
 
 #: app/app/_components/node-panel.tsx
-msgid "身份存在哪里？"
-msgstr "身分存在哪裡？"
+msgid "身份存储"
+msgstr "身分儲存"
+
+#: app/app/_components/node-panel.tsx
+#~ msgid "身份存在哪里？"
+#~ msgstr "身分存在哪裡？"
 
 #: app/app/_lib/view-types.ts
 msgid "身份错误"

--- a/docs/app/app/_locales/zh/messages.po
+++ b/docs/app/app/_locales/zh/messages.po
@@ -14,8 +14,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: app/app/_components/node-panel.tsx
-msgid "· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
-msgstr "· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
+#~ msgid "· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
+#~ msgstr "· 刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
 
 #: app/app/_components/node-panel.tsx
 msgid "（浏览器默认）"
@@ -143,8 +143,8 @@ msgid "circuit 已撤销，对方扫这个码也拨不回来。重新建立可�
 msgstr "circuit 已撤销，对方扫这个码也拨不回来。重新建立可达后请重新生成。"
 
 #: app/app/_lib/store.ts
-msgid "localStorage（Window 主线程）"
-msgstr "localStorage（Window 主线程）"
+#~ msgid "localStorage（Window 主线程）"
+#~ msgstr "localStorage（Window 主线程）"
 
 #: app/app/_components/app-nav.tsx
 msgid "SwarmDrop 官网首页"
@@ -415,6 +415,10 @@ msgstr "别名与分组只保存在本机，不会同步给对方，也不会改
 #: app/app/_components/transfer-activity-panel.tsx
 msgid "到设备页点某台在线设备的「发送」，传输开始后会实时出现在这里。"
 msgstr "到设备页点某台在线设备的「发送」，传输开始后会实时出现在这里。"
+
+#: app/app/_components/node-panel.tsx
+msgid "刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
+msgstr "刷新后保持不变。清除浏览器数据会让本机换一个新身份，已配对的设备需要重新配对。"
 
 #: app/app/_components/pairing-panel.tsx
 msgid "刷新页面后它可能恢复可用，建议稍后再撤销一次。"
@@ -1627,8 +1631,12 @@ msgid "跟随系统"
 msgstr "跟随系统"
 
 #: app/app/_components/node-panel.tsx
-msgid "身份存在哪里？"
-msgstr "身份存在哪里？"
+msgid "身份存储"
+msgstr "身份存储"
+
+#: app/app/_components/node-panel.tsx
+#~ msgid "身份存在哪里？"
+#~ msgstr "身份存在哪里？"
 
 #: app/app/_lib/view-types.ts
 msgid "身份错误"


### PR DESCRIPTION
Web 端设置页两处视觉杂音。两处都是「缺基元 / 颜色角色用错」造成的漂移，不是审美偏好。

## 1. 「Multiaddr」是一块满对比反色胶囊

`bg-foreground` + `text-background` —— 浅色下纯黑、深色下纯白。每个类都是 token，所以在 diff 里完全不可疑，但它是整张设置页**对比度最高的元素**（约 19:1），却挂在全页优先级最低的一行（收起着的「添加自定义引导节点」）。视觉重量与信息重量正好反着。

同一页当时有**四种徽标方言**：这块反色 / 传输名的 `bg-primary/10 text-brand` / 分组计数的 `Badge variant="outline"` / 关于页特性片的 `border bg-background/50`。

改用 shared `Badge` 的 outline 档（`DESIGN.md` §5 就是这么定义 outline/ghost 的），`text-inherit` 让它跟着整行的 `text-muted-foreground → hover:text-foreground` 一起走。实测对比度 4.6:1，仍过 AA。

## 2. 「身份存在哪里？」是个裸 `<details>`

顶着浏览器默认的 ▶（全站仅有的两处非 Lucide 图形语汇之一），命中区只有那行 12px 文字高，`py-2.5` 比上面的指标条还窄，卡片下缘看着像少写了点什么。

补一个行尺度的披露基元 `_components/disclosure.tsx`（`ChevronDown` + `group-open:rotate-180` + `--ease-out-quart`，与 `SectionHeader` 同一套语汇），**设置页与节点弹窗的「网络诊断」共用** —— 那处是同一个裸 `<details>`，只修一处会造出新的不一致。

- 行高 52px，过触摸基线
- marker 关两次（`list-none` 管 Chrome/Firefox，`::-webkit-details-marker` 管旧 WebKit）
- 仍用原生 `<details>`：键盘、读屏语义、无 JS 也能展开都是白拿的
- 焦点环改负 `outline-offset`，不再被卡片的 `overflow-hidden` 裁掉左右两段（同样的毛病顺手补给了 `ConnectionPanel` 的「添加自定义引导节点」行）

### 顺带两处内容修正

- 标题从问句改为名词短语「身份存储」，答案 `localStorage` 摆在收起态右侧 —— 折叠该藏的是**后果**（清数据会换身份），一个 API 名不该收门票。
- `IDENTITY_LOCATION` 从 ``msg`localStorage（Window 主线程）` `` 降为裸字符串 `"localStorage"`：API 名任何语言都不翻译，而那个中文限定语与 API 名黏在同一个串里、整串套 `font-mono`，CJK 落回非等宽字体、字距被撑开，与紧随其后的正文明显不是一套字。限定语移进代码注释，Worker/OPFS 落地时再按运行环境派生。

## 一处诚实的取舍

那块徽标的对比度从 ~19:1 降到 4.6:1。这是有意的 —— 它本来就不该是页面上最响的东西，4.6:1 仍过 AA 正文标准。

## 验证

- `docs`：typecheck ✅ / vitest 20 ✅ / **静态导出 `next build`** ✅
- 根：vitest 203 ✅ / `check:zustand-access` ✅
- 浅色 · 深色 · 375px 三态实测截图；键盘 Tab 焦点环四边完整

约定已写进 `dev-notes/knowledge/web-app-frontend.md`（满对比反色的判据 / 披露一律走 `Disclosure` / 通栏行焦点环用负偏移）。
